### PR TITLE
chore: add contributor guide, pytest suite, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package and dev deps
+        run: |
+          python -m pip install -U pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.venv/
+venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+*.egg-info/
+dist/
+build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing
+
+Thanks for helping improve YantrikDB MCP. Maintainer-tracked tasks may appear on [GitHub Issues](https://github.com/yantrikos/yantrikdb-mcp/issues); small PRs for tests, docs, or developer ergonomics are welcome anytime.
+
+## Environment (recommended: new venv)
+
+Use **Python 3.10 through 3.13**. The `yantrikdb` engine ships native wheels for those versions; **3.14** may fail to install until the engine’s PyO3 stack supports it.
+
+From the repository root:
+
+```bash
+python3.12 -m venv .venv   # or python3.11 / python3.13 — avoid 3.14 for now
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+python -m pip install -U pip
+pip install -e ".[dev]"
+```
+
+This installs the MCP server and its runtime dependencies, plus **pytest** for the suite under `tests/`.
+
+Optional: `pip install -e ".[dev,torch]"` if you work with SentenceTransformers-based flows (see root `test_v14.py`).
+
+## Run tests
+
+```bash
+pytest
+```
+
+By default only `tests/` is collected (see `pyproject.toml`). The script `test_v14.py` at the repo root is a heavier integration check against the engine; run it explicitly if needed:
+
+```bash
+pip install -e ".[torch]"
+pytest test_v14.py -v
+```
+
+## Run the server locally
+
+```bash
+yantrikdb-mcp --help
+yantrikdb-mcp --version
+```
+
+Stdio mode (typical for Cursor / Claude Code) uses no extra flags. For SSE with auth:
+
+```bash
+export YANTRIKDB_API_KEY=$(python -c "import secrets; print(secrets.token_urlsafe(32))")
+yantrikdb-mcp --transport sse --port 8420
+```
+
+## Submitting a PR
+
+1. Fork [yantrikos/yantrikdb-mcp](https://github.com/yantrikos/yantrikdb-mcp) on GitHub.
+2. Create a branch from `main`, push your fork, open a PR with a short description of the change.
+3. If you add behavior, add or extend tests in `tests/`. Doc-only changes are fine without tests.
+
+## License
+
+This package is MIT. The `yantrikdb` engine dependency is AGPL-3.0; see the [README](README.md) for a short explanation of how that applies.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ YantrikDB MCP Server stores all data **locally on your machine** (default: `~/.y
 
 Full policy: [yantrikdb.com/privacy](https://yantrikdb.com/privacy/)
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for a venv setup, running `pytest`, and opening PRs.
+
 ## Support
 
 - **Issues:** [github.com/yantrikos/yantrikdb-mcp/issues](https://github.com/yantrikos/yantrikdb-mcp/issues)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
 torch = ["sentence-transformers>=3.0.0"]
 
 [project.scripts]
@@ -46,3 +49,6 @@ Issues = "https://github.com/yantrikos/yantrikdb-mcp/issues"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,110 @@
+"""Unit tests for network transport bearer auth (no YantrikDB calls)."""
+
+import asyncio
+import json
+
+import pytest
+
+from yantrikdb_mcp.auth import BearerTokenMiddleware
+
+
+def _http_scope(*, headers: list[tuple[bytes, bytes]] | None = None) -> dict:
+    return {"type": "http", "headers": headers or []}
+
+
+@pytest.fixture
+def echo_app():
+    """Minimal ASGI app that returns 200 + body."""
+
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [[b"content-type", b"text/plain"]],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    return app
+
+
+def test_bearer_401_when_missing(echo_app):
+    mw = BearerTokenMiddleware(echo_app, api_key="secret")
+    events: list[dict] = []
+
+    async def run():
+        async def send(e):
+            events.append(e)
+
+        async def receive():
+            return {"type": "http.disconnect"}
+
+        await mw(_http_scope(), receive, send)
+
+    asyncio.run(run())
+
+    assert events[0]["type"] == "http.response.start"
+    assert events[0]["status"] == 401
+    body = json.loads(events[1]["body"].decode())
+    assert "error" in body
+
+
+def test_bearer_401_when_wrong_token(echo_app):
+    mw = BearerTokenMiddleware(echo_app, api_key="secret")
+    events: list[dict] = []
+
+    async def run():
+        async def send(e):
+            events.append(e)
+
+        async def receive():
+            return {"type": "http.disconnect"}
+
+        scope = _http_scope(headers=[(b"authorization", b"Bearer wrong")])
+        await mw(scope, receive, send)
+
+    asyncio.run(run())
+    assert events[0]["status"] == 401
+
+
+def test_bearer_allows_valid_token(echo_app):
+    mw = BearerTokenMiddleware(echo_app, api_key="secret")
+    events: list[dict] = []
+
+    async def run():
+        async def send(e):
+            events.append(e)
+
+        async def receive():
+            return {"type": "http.disconnect"}
+
+        scope = _http_scope(headers=[(b"authorization", b"Bearer secret")])
+        await mw(scope, receive, send)
+
+    asyncio.run(run())
+    assert events[0]["status"] == 200
+    assert events[1]["body"] == b"ok"
+
+
+def test_non_http_passthrough():
+    """Lifespan and similar scopes should not require Authorization."""
+
+    reached: list[str] = []
+
+    async def app(scope, receive, send):
+        reached.append(scope["type"])
+
+    mw = BearerTokenMiddleware(app, api_key="secret")
+
+    async def run():
+        async def send(_):
+            pass
+
+        async def receive():
+            return {"type": "http.disconnect"}
+
+        await mw({"type": "lifespan"}, receive, send)
+
+    asyncio.run(run())
+    assert reached == ["lifespan"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,28 @@
+"""Smoke tests for the console entrypoint (subprocess — real install layout)."""
+
+import subprocess
+import sys
+
+
+def test_version_exits_zero():
+    proc = subprocess.run(
+        [sys.executable, "-m", "yantrikdb_mcp", "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "yantrikdb-mcp" in proc.stdout
+
+
+def test_help_exits_zero():
+    proc = subprocess.run(
+        [sys.executable, "-m", "yantrikdb_mcp", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    out = proc.stdout + proc.stderr
+    assert "--transport" in out
+    assert "YANTRIKDB_DB_PATH" in out


### PR DESCRIPTION
- CONTRIBUTING.md: venv setup, Python 3.10–3.13 note, pytest and PR flow
- tests: bearer auth middleware and CLI --version/--help smoke tests
- pyproject: optional dev extra (pytest), pytest testpaths
- CI: run pytest on Python 3.10 and 3.12 for pushes and PRs to main
- README: link to CONTRIBUTING.md
- .gitignore: venv and common Python artifacts