### PR TITLE
fix(ci): decouple [dev] from [onnx], install per-backend in e2e jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
-      - name: Install package + dev deps (with [onnx] for full coverage)
+      - name: Install package + dev + ONNX (unit tests exercise both paths)
         run: |
           python -m pip install -U pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,onnx]"
 
       - name: Run unit tests (excluding e2e)
         run: pytest -q --ignore=tests/test_e2e_mcp.py
@@ -45,13 +45,16 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install package (bundled only)
+      # Each backend installs only the deps required for ITS path. The e2e
+      # parametrize computes BACKENDS from what's importable in the env, so
+      # this way each job runs exactly one backend variant — no cross-
+      # contamination (e.g. an [onnx] case running in the bundled job because
+      # ONNX deps happened to be present).
+      - name: Install package (bundled — base deps only)
         if: matrix.backend == 'bundled'
         run: |
           python -m pip install -U pip
           pip install -e ".[dev]"
-          # Strip ONNX deps so we exercise the bundled-only install path
-          pip uninstall -y onnxruntime tokenizers huggingface-hub numpy || true
 
       - name: Install package + ONNX extras
         if: matrix.backend == 'onnx'
@@ -59,7 +62,7 @@ jobs:
           python -m pip install -U pip
           pip install -e ".[dev,onnx]"
 
-      - name: Install package (multilingual uses bundled-only deps; model is engine-downloaded)
+      - name: Install package (multilingual — base deps only; model is engine-downloaded)
         if: matrix.backend == 'multilingual'
         run: |
           python -m pip install -U pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           allow-prereleases: true
       - run: |
           python -m pip install -U pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,onnx]"
       - run: pytest -q --ignore=tests/test_e2e_mcp.py
 
   e2e:
@@ -39,18 +39,20 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install (bundled only)
+      # Each backend job installs only its required deps so the e2e
+      # parametrize computes BACKENDS = [<this backend>] and never runs
+      # cross-backend variants.
+      - name: Install (bundled — base deps only)
         if: matrix.backend == 'bundled'
         run: |
           python -m pip install -U pip
           pip install -e ".[dev]"
-          pip uninstall -y onnxruntime tokenizers huggingface-hub numpy || true
       - name: Install (with ONNX)
         if: matrix.backend == 'onnx'
         run: |
           python -m pip install -U pip
           pip install -e ".[dev,onnx]"
-      - name: Install (multilingual — bundled deps, engine fetches model)
+      - name: Install (multilingual — base deps only; engine fetches model)
         if: matrix.backend == 'multilingual'
         run: |
           python -m pip install -U pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,6 @@ onnx = [
 ]
 dev = [
     "pytest>=8.0",
-    # Dev environments need ONNX so the existing 384-dim test fixtures work.
-    "yantrikdb-mcp[onnx]",
 ]
 torch = ["sentence-transformers>=3.0.0"]
 


### PR DESCRIPTION
The v0.7.0 commit's CI failed: the multilingual e2e job installed `[dev]` which pulls `[onnx]` transitively, so the e2e parametrize ran all three backend variants — and the `[onnx]` case tried to download MiniLM at test time and hit `HF_HUB_OFFLINE`.

### Fix

- Drop `yantrikdb-mcp[onnx]` from `[dev]`. `[dev]` is now just `pytest`. Contributors who want both code paths run `pip install -e ".[dev,onnx]"`.
- Unit-test jobs install `[dev,onnx]` so both branches of `load_engine` are exercised.
- E2E jobs install only what the job's backend needs:
  - `bundled` → `[dev]` → BACKENDS resolves to `["bundled"]`
  - `onnx` → `[dev,onnx]` → BACKENDS = `["bundled", "onnx"]`
  - `multilingual` → `[dev]` → BACKENDS = `["bundled", "multilingual"]` (no ONNX import, no MiniLM fetch attempt)
- Dropped the `pip uninstall onnxruntime ...` workaround that was needed when `[dev]` dragged in ONNX.

Same change in `publish.yml`. Verified by inspecting the failing run (25847235636) — the only failing assertion was `assert "rid" in rcontent` on the `onnx` parametrize inside the `multilingual` job; the bundled and multilingual cases passed.

### Local verification

- Full pytest (with `YANTRIKDB_TEST_MULTILINGUAL=1`): 26 passed
- Clean-venv install (default): only `yantrikdb` + `yantrikdb-mcp` on the wire, e2e/bundled passes
- Clean-venv install with `[onnx]` extra: e2e/bundled + e2e/onnx pass