### PR TITLE
v0.8.1: split outcome gate from define gate (closes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Supports `sse` and `streamable-http` transports. Note: SSE connections can drop 
 | `YANTRIKDB_DB_PATH` | Local | `~/.yantrikdb/memory.db` | Database file path |
 | `YANTRIKDB_EMBEDDER` | Local | `auto` | Backend selector: `auto` \| `bundled` \| `onnx` \| `multilingual` |
 | `YANTRIKDB_EMBEDDING_MODEL` | Local | `all-MiniLM-L6-v2` | ONNX model name (only used when `YANTRIKDB_EMBEDDER=onnx`) |
-| `YANTRIKDB_SKILLS_WRITE_ENABLED` | All | `false` | Set `true` to allow agents to author skills (see [Skill substrate](#skill-substrate-v070) below) |
+| `YANTRIKDB_SKILLS_WRITE_ENABLED` | All | `false` | Set `true` to allow agents to author skills via `skill(action="define")` (see [Skill substrate](#skill-substrate-v070) below) |
+| `YANTRIKDB_OUTCOMES_WRITE_ENABLED` | All | `true` | Outcome tracking via `skill(action="outcome")`. Defaults on so the feedback loop works out of the box; set `false` to lock the outcome substrate. Added in v0.8.1 per [#8](https://github.com/yantrikos/yantrikdb-mcp/issues/8) |
 | `YANTRIKDB_API_KEY` | SSE server | *(none)* | Bearer token when serving SSE/HTTP |
 
 ### Embedder backends
@@ -198,8 +199,9 @@ Skill writes shape future agent behavior across sessions, so the MCP server impl
 | **B2** Author attribution | Records `session_id`, `os_user`, `hostname`, `wall_clock`, `audit_nonce` | (always on) | Forensic trail |
 | **B3** Cross-origin replace | Refuse to overwrite a skill written by a different consumer | `YANTRIKDB_SKILLS_ALLOW_CROSS_ORIGIN_REPLACE=true` to allow | Defends against MCP↔hermes-plugin collision |
 | **B4** Supersedes integrity | `supersedes` must reference an existing skill in the same namespace | (always on) | Blocks malicious retirement of legit skills |
-| **C1** Time-bound gate | Gate auto-closes at the timestamp | `YANTRIKDB_SKILLS_WRITE_EXPIRES_AT=2026-12-31T00:00:00Z` | Unset = no expiry |
-| **C2** Locked config | All `YANTRIKDB_SKILLS_*` env vars read once at startup | (always on) | Mutating env in a sub-process can't bypass the gate |
+| **C1** Time-bound gate | Gate auto-closes at the timestamp (applies to both define + outcome) | `YANTRIKDB_SKILLS_WRITE_EXPIRES_AT=2026-12-31T00:00:00Z` | Unset = no expiry |
+| **C1.5** Split outcome gate | `outcome` action uses its own gate, default ON | `YANTRIKDB_OUTCOMES_WRITE_ENABLED=false` to lock outcomes too | v0.8.1+: `define` and `outcome` have different threat profiles — outcome can't introduce new instructions, only append `{succeeded, note≤500}` against an existing skill. Feedback loop works by default; lock explicitly if needed |
+| **C2** Locked config | All `YANTRIKDB_SKILLS_*` / `YANTRIKDB_OUTCOMES_*` env vars read once at startup | (always on) | Mutating env in a sub-process can't bypass the gate |
 | **D1** Audit log | JSONL append of every accept/reject/tamper event | `YANTRIKDB_SKILLS_AUDIT_LOG=/var/log/yantrikdb/skills.jsonl` | Unset = no auditing (warns at boot) |
 | **D2** Rate limit | Per-session-id sliding-window write cap | `YANTRIKDB_SKILLS_WRITE_RATE=30` (default writes/min) | Defeats flood attacks |
 | **D3** Outcome.note guards | Note ≤500 chars + scanned by A1/A2/A4 | (always on) | Closes the outcome side-channel |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.8.0"
+version = "0.8.1"
 description = "YantrikDB MCP Server — Cognitive memory for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/yantrikdb_mcp/skill_security.py
+++ b/src/yantrikdb_mcp/skill_security.py
@@ -73,7 +73,19 @@ class _Config:
     def __init__(self) -> None:
         # The gate itself (already used by tools.py)
         self.writes_enabled = _read_bool("YANTRIKDB_SKILLS_WRITE_ENABLED")
-        # C1 — time-bound gate
+        # Outcome gate — split from writes_enabled in v0.8.1 (issue #8).
+        # `outcome` calls cannot introduce new instructions (they only
+        # append {succeeded, note≤500} against an already-validated
+        # skill_id, with the same A1/A2/A4 content scan + D2 rate
+        # limit applied), so their threat profile is meaningfully
+        # different from `define`. Default TRUE so the feedback loop
+        # works out of the box; operators can flip to false if they
+        # want to lock the outcome substrate too.
+        self.outcomes_enabled = _read_bool_default(
+            "YANTRIKDB_OUTCOMES_WRITE_ENABLED", default=True
+        )
+        # C1 — time-bound gate (applies to both define + outcome —
+        # forensic concerns are the same once writes are flowing)
         self.write_expires_at = _read_iso("YANTRIKDB_SKILLS_WRITE_EXPIRES_AT")
         # B1 — namespace allowlist
         ns_raw = _read_list("YANTRIKDB_SKILLS_ALLOWED_NAMESPACES")
@@ -111,6 +123,7 @@ class _Config:
         """JSON-able snapshot for the audit log."""
         return {
             "writes_enabled": self.writes_enabled,
+            "outcomes_enabled": self.outcomes_enabled,
             "write_expires_at": self.write_expires_at.isoformat() if self.write_expires_at else None,
             "allowed_namespaces": list(self.allowed_namespaces),
             "allow_cross_origin_replace": self.allow_cross_origin_replace,
@@ -145,15 +158,36 @@ def config() -> _Config:
 # ─────────────────────────────────────────────────────────────────────
 
 
-def gate_open() -> tuple[bool, str | None]:
-    """Returns (is_open, reason_if_closed). Combines the writes_enabled
-    bool with the optional expiry timestamp."""
-    if not CONFIG.writes_enabled:
-        return False, (
-            "YANTRIKDB_SKILLS_WRITE_ENABLED is false. Skill writes are "
-            "off by default; set the env var to true on the MCP server "
-            "to enable agent-authored skills."
-        )
+def gate_open(action: str = "define") -> tuple[bool, str | None]:
+    """Returns (is_open, reason_if_closed) for the given action.
+
+    Two gates in v0.8.1+ (yantrikos/yantrikdb-mcp#8):
+      - `define` (and `replace`): YANTRIKDB_SKILLS_WRITE_ENABLED, default FALSE
+      - `outcome`: YANTRIKDB_OUTCOMES_WRITE_ENABLED, default TRUE
+
+    Both share the C1 time-bound expiry — once it fires, all writes
+    are refused regardless of which flag opened them.
+
+    Default arg is "define" so existing callers (and tests) that don't
+    pass action keep the v0.8.0 semantics.
+    """
+    if action == "outcome":
+        if not CONFIG.outcomes_enabled:
+            return False, (
+                "YANTRIKDB_OUTCOMES_WRITE_ENABLED is false. Skill outcome "
+                "tracking is disabled on this MCP server. Set the env var "
+                "to true (or unset — it defaults to true) to enable the "
+                "feedback loop."
+            )
+    else:
+        # All other write actions (define, replace) use the stricter gate
+        if not CONFIG.writes_enabled:
+            return False, (
+                "YANTRIKDB_SKILLS_WRITE_ENABLED is false. Skill writes are "
+                "off by default; set the env var to true on the MCP server "
+                "to enable agent-authored skills."
+            )
+
     if CONFIG.write_expires_at is not None:
         now = datetime.now(timezone.utc)
         if now >= CONFIG.write_expires_at:

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -1267,8 +1267,11 @@ def skill(
     session_id = session_id or "default"
 
     # ── Gate (C1 + C2 + base) ──
+    # v0.8.1 (issue #8): define/replace use the strict YANTRIKDB_SKILLS_WRITE_ENABLED
+    # gate; outcome uses the lighter YANTRIKDB_OUTCOMES_WRITE_ENABLED (default
+    # true). `gate_open(action)` dispatches.
     if action in ("define", "outcome"):
-        is_open, reason = gate_open()
+        is_open, reason = gate_open(action)
         if not is_open:
             COUNTERS.reject_define(reason="gate_closed") if action == "define" else COUNTERS.reject_outcome("gate_closed")
             audit_event({

--- a/tests/test_e2e_mcp.py
+++ b/tests/test_e2e_mcp.py
@@ -339,6 +339,56 @@ def test_skill_define_surface_outcome_roundtrip(tmp_path: Path):
             proc.wait()
 
 
+def test_skill_outcomes_can_be_locked_explicitly(tmp_path: Path):
+    """v0.8.1 issue #8: operators who want a fully-locked substrate can
+    flip OUTCOMES off with the explicit env var, even though it defaults
+    to true. Verifies outcome refusal carries the specific reason text."""
+    db_path = tmp_path / "e2e_skills_outcomes_off.db"
+    env = {
+        k: v for k, v in os.environ.items()
+        if k not in ("YANTRIKDB_SKILLS_WRITE_ENABLED",
+                     "YANTRIKDB_OUTCOMES_WRITE_ENABLED")
+    }
+    env.update({
+        "YANTRIKDB_DB_PATH": str(db_path),
+        "YANTRIKDB_EMBEDDER": "bundled",
+        "YANTRIKDB_OUTCOMES_WRITE_ENABLED": "false",
+        "PYTHONIOENCODING": "utf-8",
+        "HF_HUB_OFFLINE": "1",
+    })
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "yantrikdb_mcp"],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=env,
+    )
+    try:
+        _rpc(proc, "initialize", {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "outcome-lock-e2e", "version": "0.0"},
+        }, msg_id=1)
+        _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+        outcome_resp = _rpc(proc, "tools/call", {
+            "name": "skill",
+            "arguments": {
+                "action": "outcome",
+                "skill_id": "workflow.git.commit_clean",
+                "succeeded": True,
+            },
+        }, msg_id=2)
+        body = json.dumps(outcome_resp)
+        assert "YANTRIKDB_OUTCOMES_WRITE_ENABLED" in body, (
+            f"explicit OUTCOMES=false must refuse with the outcome gate reason: {outcome_resp}"
+        )
+    finally:
+        try: _send(proc, {"jsonrpc": "2.0", "method": "notifications/cancelled"})
+        except Exception: pass
+        proc.stdin.close()
+        try: proc.wait(timeout=5)
+        except subprocess.TimeoutExpired: proc.kill()
+
+
 def test_skill_writes_disabled_by_default(tmp_path: Path):
     """Without `YANTRIKDB_SKILLS_WRITE_ENABLED`, the `define` and `outcome`
     actions must be refused with a clear error. Reads must still work."""
@@ -371,7 +421,7 @@ def test_skill_writes_disabled_by_default(tmp_path: Path):
         }, msg_id=1)
         _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
 
-        # define is gated
+        # v0.8.1 (issue #8): define is gated; outcome is NOT gated by default
         define_resp = _rpc(proc, "tools/call", {
             "name": "skill",
             "arguments": {
@@ -388,7 +438,11 @@ def test_skill_writes_disabled_by_default(tmp_path: Path):
             f"define should be gated by default: {define_resp}"
         )
 
-        # outcome is also gated
+        # Outcome calls against a non-existent skill still produce *some*
+        # response (the schema-validate path runs against the skill_id);
+        # the key v0.8.1 behaviour is that they are NOT refused by the
+        # YANTRIKDB_SKILLS_WRITE_ENABLED gate. They go through the
+        # YANTRIKDB_OUTCOMES_WRITE_ENABLED gate which defaults to true.
         outcome_resp = _rpc(proc, "tools/call", {
             "name": "skill",
             "arguments": {
@@ -397,21 +451,25 @@ def test_skill_writes_disabled_by_default(tmp_path: Path):
                 "succeeded": True,
             },
         }, msg_id=3)
-        is_error = outcome_resp.get("result", {}).get("isError")
+        is_error = outcome_resp.get("result", {}).get("isError", False)
         body = json.dumps(outcome_resp)
-        assert is_error is True or "YANTRIKDB_SKILLS_WRITE_ENABLED" in body, (
-            f"outcome should be gated by default: {outcome_resp}"
+        # Must NOT contain the skill-writes-gate refusal text
+        assert "YANTRIKDB_SKILLS_WRITE_ENABLED is false" not in body, (
+            f"v0.8.1: outcome must not be blocked by the define gate: {outcome_resp}"
         )
+        # Either it succeeded (skill happened to exist from a prior test) or
+        # it ran far enough to write the outcome event. Either way it didn't
+        # short-circuit on the gate.
+        assert is_error is False, f"outcome should succeed when default gates apply: {outcome_resp}"
 
-        # Reads ARE allowed even when the gate is off — they only return
-        # skills someone authorized into the substrate. List should return
-        # an empty result, not an error.
+        # Reads ARE allowed even when the define gate is off
         list_resp = _rpc(proc, "tools/call", {
             "name": "skill",
             "arguments": {"action": "list", "limit": 10},
         }, msg_id=4)
         assert "result" in list_resp, f"list failed when gate off: {list_resp}"
         list_obj = json.loads(list_resp["result"]["content"][0]["text"])
+        # No defines happened this session, so count == 0
         assert list_obj.get("count", -1) == 0, (
             f"list with gate off and no skills should be empty: {list_obj}"
         )

--- a/tests/test_skill_security.py
+++ b/tests/test_skill_security.py
@@ -277,6 +277,75 @@ def test_c2_config_frozen_after_init(monkeypatch):
 
 
 # ─────────────────────────────────────────────────────────────────────
+# Issue #8 — split outcome gate (v0.8.1)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_outcome_gate_default_open(monkeypatch):
+    """Per issue #8: outcomes are default-on so the feedback loop works
+    out of the box, even when YANTRIKDB_SKILLS_WRITE_ENABLED is false."""
+    from yantrikdb_mcp import skill_security
+    monkeypatch.setattr(skill_security.CONFIG, "writes_enabled", False)
+    monkeypatch.setattr(skill_security.CONFIG, "outcomes_enabled", True)
+    monkeypatch.setattr(skill_security.CONFIG, "write_expires_at", None)
+    # define remains closed
+    assert skill_security.gate_open("define")[0] is False
+    # outcome is open
+    assert skill_security.gate_open("outcome") == (True, None)
+
+
+def test_outcome_gate_can_be_closed_explicitly(monkeypatch):
+    """Operators who want a fully-locked substrate can flip outcomes
+    off via YANTRIKDB_OUTCOMES_WRITE_ENABLED=false."""
+    from yantrikdb_mcp import skill_security
+    monkeypatch.setattr(skill_security.CONFIG, "writes_enabled", True)
+    monkeypatch.setattr(skill_security.CONFIG, "outcomes_enabled", False)
+    monkeypatch.setattr(skill_security.CONFIG, "write_expires_at", None)
+    # define stays open
+    assert skill_security.gate_open("define") == (True, None)
+    # outcome refused with the specific reason
+    is_open, reason = skill_security.gate_open("outcome")
+    assert is_open is False
+    assert "YANTRIKDB_OUTCOMES_WRITE_ENABLED" in reason
+
+
+def test_outcome_gate_env_default_true(monkeypatch):
+    """A fresh _Config() with no env set must produce outcomes_enabled=True."""
+    from yantrikdb_mcp import skill_security
+    monkeypatch.delenv("YANTRIKDB_OUTCOMES_WRITE_ENABLED", raising=False)
+    cfg = skill_security._Config()
+    assert cfg.outcomes_enabled is True
+
+
+def test_outcome_gate_env_explicit_false(monkeypatch):
+    from yantrikdb_mcp import skill_security
+    monkeypatch.setenv("YANTRIKDB_OUTCOMES_WRITE_ENABLED", "false")
+    cfg = skill_security._Config()
+    assert cfg.outcomes_enabled is False
+
+
+def test_expiry_closes_outcome_gate_too(monkeypatch):
+    """C1 time-bound expiry shuts BOTH gates — once writes are flowing,
+    the forensic / audit concerns apply uniformly."""
+    from datetime import datetime, timedelta, timezone
+    from yantrikdb_mcp import skill_security
+    monkeypatch.setattr(skill_security.CONFIG, "writes_enabled", True)
+    monkeypatch.setattr(skill_security.CONFIG, "outcomes_enabled", True)
+    past = datetime.now(timezone.utc) - timedelta(minutes=5)
+    monkeypatch.setattr(skill_security.CONFIG, "write_expires_at", past)
+    for action in ("define", "outcome"):
+        is_open, reason = skill_security.gate_open(action)
+        assert is_open is False, f"{action} should be closed by expiry"
+        assert "EXPIRES_AT" in reason
+
+
+def test_snapshot_includes_outcomes_enabled():
+    from yantrikdb_mcp.skill_security import _Config
+    snap = _Config().snapshot()
+    assert "outcomes_enabled" in snap, "audit log snapshot must record both gates"
+
+
+# ─────────────────────────────────────────────────────────────────────
 # D — operational
 # ─────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #8.

@blue-mtn-dog filed [#8](https://github.com/yantrikos/yantrikdb-mcp/issues/8) within hours of v0.8.0 release with a precise critique of the gate design: `YANTRIKDB_SKILLS_WRITE_ENABLED` uniformly gates both `define` and `outcome`, forcing operators into an all-or-nothing choice.

They're right. The two actions have meaningfully different threat profiles — `define` creates new persistent instructions (high injection risk), `outcome` only appends `{succeeded: bool, note ≤500 chars}` against an *already-validated* skill_id (low injection risk; can't change what `surface` returns). Gating them the same defeats the feedback loop in normal operation.

## Change

Split into two env-var gates:

| Var | Default | Gates |
|---|---|---|
| `YANTRIKDB_SKILLS_WRITE_ENABLED` | `false` *(unchanged)* | `define`, `replace` |
| `YANTRIKDB_OUTCOMES_WRITE_ENABLED` | **`true` (new)** | `outcome` |

`C1` time-bound expiry still shuts BOTH gates — once writes are flowing, forensic/audit concerns apply uniformly regardless of which action opened them.

API surface:
```python
skill_security.gate_open(action="define")   # existing v0.8.0 semantics
skill_security.gate_open(action="outcome")  # new outcome gate
```

Default arg is `"define"` so callers/tests that didn't pass `action` keep v0.8.0 behavior.

## Tests

- **+6 unit tests** (default-open outcome, explicit lock, env parsing, expiry-closes-both, snapshot)
- **+1 e2e test** for explicit `OUTCOMES=false` refusal carrying the new reason text
- **~1 e2e test updated** — `test_skill_writes_disabled_by_default` now asserts outcome WORKS by default (the v0.8.1 contract); define is still gated as before
- **Local: 115 tests pass**

## Audit-log compatibility

`config_snapshot` now includes `outcomes_enabled` alongside `writes_enabled`, so operators reading `/var/log/yantrikdb/skills.audit.jsonl` can see exactly which gate state was in effect for each event. Existing audit-log consumers that read fields by name are unaffected.

## Migration

None required. Default behavior:
- Pre-v0.8.1 users who never set `YANTRIKDB_SKILLS_WRITE_ENABLED`: define still refused (same), outcome now works (was refused, now allowed by default)
- Pre-v0.8.1 users with `YANTRIKDB_SKILLS_WRITE_ENABLED=true`: both still work (same)
- Operators who want the old lock-everything behavior: add `YANTRIKDB_OUTCOMES_WRITE_ENABLED=false`