### PR TITLE
v0.8.3: process-singleton _LazyDB + atexit close (closes #11)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.8.2"
+version = "0.8.3"
 description = "YantrikDB MCP Server — Cognitive memory for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/yantrikdb_mcp/server.py
+++ b/src/yantrikdb_mcp/server.py
@@ -1,5 +1,6 @@
 """FastMCP server definition with YantrikDB lifespan context."""
 
+import atexit
 import logging
 import os
 import sys
@@ -166,15 +167,40 @@ class _LazyDB:
         return self._db
 
     def close(self):
-        if self._db is not None:
-            self._db.close()
+        """Idempotent — safe to call multiple times (atexit + any other
+        cleanup path). After the first call, `_db` is nulled so a second
+        call is a no-op and there's no double-close on the SQLite handle.
+        Also tolerates engines that don't expose a `close()` method
+        (HTTP backend) by swallowing AttributeError."""
+        with self._init_lock:
+            db, self._db = self._db, None
+        if db is None:
+            return
+        try:
+            db.close()
+        except AttributeError:
+            # HTTP backend doesn't need explicit close; engine handle
+            # has no close on older variants either.
+            pass
+
+
+_safety_warnings_emitted = False
+_safety_warnings_lock = threading.Lock()
 
 
 def _emit_skill_safety_warnings() -> None:
     """F — log startup warnings about dangerous skill-substrate
-    configurations. Always called once at lifespan start. Warnings
-    also land in the audit log if one is configured."""
+    configurations. Emitted once per process lifetime — under SSE
+    transport the lifespan may be entered multiple times (per-session)
+    and we don't want to spam the journal or pollute the audit log
+    with duplicate startup-warning events on every reconnect."""
+    global _safety_warnings_emitted
     from .skill_security import audit_event, config, startup_safety_checks
+
+    with _safety_warnings_lock:
+        if _safety_warnings_emitted:
+            return
+        _safety_warnings_emitted = True
 
     is_cluster = bool(os.environ.get("YANTRIKDB_SERVER_URL", "").strip())
     # We can't easily probe actor_ids before DB open — pass None and
@@ -191,17 +217,55 @@ def _emit_skill_safety_warnings() -> None:
         })
 
 
+# Process-singleton `_LazyDB`. Under SSE transport, FastMCP/uvicorn
+# enters the `lifespan` context once per client session. The v0.8.1
+# implementation constructed a fresh `_LazyDB` on every entry and
+# called `close()` on every exit — when sessions overlap (rapid
+# reconnects, kill mid-drain, macOS sleep/wake), multiple instances
+# raced to checkpoint+close the same SQLite WAL, partially overwriting
+# the main DB on any interrupted close. Pinned as a singleton here per
+# yantrikos/yantrikdb-mcp#11. The Rust engine is internally
+# Mutex/RwLock-protected (per the docstring on `_LazyDB`), so one
+# shared instance across sessions is the *intended* threading model
+# — we're just making the implementation match.
+_lazy_singleton: "_LazyDB | None" = None
+_lazy_singleton_lock = threading.Lock()
+
+
+def _get_lazy_singleton() -> "_LazyDB":
+    global _lazy_singleton
+    if _lazy_singleton is None:
+        with _lazy_singleton_lock:
+            if _lazy_singleton is None:
+                _lazy_singleton = _LazyDB()
+                # Register a single orderly close at interpreter exit.
+                # We deliberately do NOT register signal handlers — they
+                # interact badly with uvicorn's own SIGTERM handling.
+                # `atexit` runs once after Python's normal shutdown which
+                # is the right hook for "the only owner of the SQLite
+                # handle is closing now."
+                atexit.register(_lazy_singleton.close)
+    return _lazy_singleton
+
+
 @asynccontextmanager
 async def lifespan(app: FastMCP):
-    """Provide a lazy-initialized YantrikDB context — model loads on first tool call."""
-    lazy = _LazyDB()
+    """Provide a process-singleton YantrikDB context.
+
+    Under stdio transport this runs once. Under SSE transport FastMCP
+    may re-enter this for each new client session — that's fine, every
+    session yields the same `_LazyDB` instance. Close happens once via
+    `atexit`, not per-session. See yantrikos/yantrikdb-mcp#11.
+    """
+    lazy = _get_lazy_singleton()
     log.info("YantrikDB MCP server started (model loads on first use)")
     _emit_skill_safety_warnings()
     try:
         yield {"lazy": lazy}
     finally:
-        log.info("Shutting down YantrikDB")
-        lazy.close()
+        # No per-session close. The singleton lives for the lifetime of
+        # the process and is closed exactly once by the atexit hook.
+        pass
 
 
 mcp = FastMCP("yantrikdb", instructions=INSTRUCTIONS, lifespan=lifespan)

--- a/tests/test_server_singleton.py
+++ b/tests/test_server_singleton.py
@@ -1,0 +1,118 @@
+"""Tests for the v0.8.3 process-singleton `_LazyDB` + atexit close
+(yantrikos/yantrikdb-mcp#11).
+
+Background: under SSE transport the lifespan ran once per client
+session, each constructing its own `_LazyDB` with its own SQLite
+handle. Multiple instances racing to checkpoint+close the same WAL on
+process exit corrupted the on-disk DB. The fix pins one `_LazyDB`
+per-process, registers a single atexit close, and de-duplicates the
+startup safety-warning emit so reconnects don't spam the journal.
+"""
+
+from __future__ import annotations
+
+import atexit
+import importlib
+import threading
+
+
+def _reload_server():
+    """Fresh import so module-level singletons reset between tests."""
+    from yantrikdb_mcp import server
+    return importlib.reload(server)
+
+
+def test_singleton_is_same_across_calls():
+    server = _reload_server()
+    a = server._get_lazy_singleton()
+    b = server._get_lazy_singleton()
+    assert a is b, "every caller must see the same _LazyDB instance"
+
+
+def test_singleton_initialised_only_once_under_threads():
+    server = _reload_server()
+    results = []
+    barrier = threading.Barrier(8)
+
+    def race():
+        barrier.wait()
+        results.append(server._get_lazy_singleton())
+
+    threads = [threading.Thread(target=race) for _ in range(8)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+
+    assert len({id(r) for r in results}) == 1, (
+        "double-checked locking must yield a single instance under contention"
+    )
+
+
+def test_atexit_close_is_registered(monkeypatch):
+    """The first `_get_lazy_singleton()` call must register the close
+    callback exactly once. We can't assert on Python's atexit list
+    directly (private), so we monkeypatch atexit.register and verify."""
+    server = _reload_server()
+    registered = []
+    monkeypatch.setattr(atexit, "register", lambda fn: registered.append(fn) or fn)
+
+    s1 = server._get_lazy_singleton()
+    s2 = server._get_lazy_singleton()
+    assert s1 is s2
+    assert len(registered) == 1, "atexit.register should fire exactly once"
+    # And the callable should be the singleton's close method
+    assert registered[0] == s1.close
+
+
+def test_close_is_idempotent():
+    server = _reload_server()
+    s = server._get_lazy_singleton()
+
+    # Stub the inner _db so close() actually has something to close
+    closes = []
+    class _FakeDB:
+        def close(self): closes.append("called")
+    s._db = _FakeDB()
+
+    s.close()
+    s.close()  # second call must be a no-op, no AttributeError
+    s.close()
+    assert closes == ["called"], "engine close should fire exactly once"
+    assert s._db is None, "_db must be nulled after close"
+
+
+def test_close_tolerates_engine_without_close_method():
+    """HTTP backend or older engines may not expose close(); the
+    wrapper should swallow AttributeError so atexit can run cleanly
+    in cluster mode."""
+    server = _reload_server()
+    s = server._get_lazy_singleton()
+    s._db = object()  # bare object — no .close() attribute
+    s.close()  # must not raise
+    assert s._db is None
+
+
+def test_safety_warnings_emitted_once_per_process(monkeypatch):
+    """Under SSE the lifespan re-enters per session — startup safety
+    warnings must NOT re-fire on every reconnect."""
+    server = _reload_server()
+    calls = []
+    monkeypatch.setattr(
+        "yantrikdb_mcp.skill_security.startup_safety_checks",
+        lambda **kw: (calls.append(kw) or ["[F.test] dummy warning"]),
+    )
+    monkeypatch.setattr(
+        "yantrikdb_mcp.skill_security.audit_event",
+        lambda evt: calls.append(evt),
+    )
+
+    # Simulate multiple lifespan entries (what SSE does on reconnect)
+    server._emit_skill_safety_warnings()
+    server._emit_skill_safety_warnings()
+    server._emit_skill_safety_warnings()
+
+    # Exactly one safety-check probe + one audit event from the first call;
+    # subsequent calls short-circuit on the de-dupe flag.
+    probe_calls = [c for c in calls if isinstance(c, dict) and "is_cluster_mode" in c]
+    audit_calls = [c for c in calls if isinstance(c, dict) and c.get("event") == "startup_safety_warnings"]
+    assert len(probe_calls) == 1, f"safety check should fire once, fired {len(probe_calls)}"
+    assert len(audit_calls) == 1, f"audit emit should fire once, fired {len(audit_calls)}"


### PR DESCRIPTION
Closes #11.

@blue-mtn-dog filed [#11](https://github.com/yantrikos/yantrikdb-mcp/issues/11) with **five reproductions** of on-disk SQLite corruption under SSE transport over multiple days. Their root-cause analysis matched the code exactly:

- The lifespan in `server.py` constructs a fresh `_LazyDB()` per invocation (line ~197 in v0.8.2)
- Under SSE transport (`mcp.sse_app()` via uvicorn), each MCP client session drives an independent lifespan
- Multiple `_LazyDB` instances → multiple SQLite handles → race on close+checkpoint when sessions overlap (rapid reconnect, kill mid-drain, macOS sleep/wake)
- Any close interrupted by process death partially overwrites the main DB → `file is not a database` on next start → data loss

The `_LazyDB` docstring already documented that the Rust engine is internally `Mutex`/`RwLock`-protected and intended to be shared — process-singleton was the *designed* threading model, just not enforced.

## Fix

| Change | Why |
|---|---|
| Module-level `_lazy_singleton` + `_get_lazy_singleton()` with double-checked locking | One `_LazyDB` per process, period |
| `atexit.register(close)` on first creation | Exactly one orderly close at interpreter exit |
| Lifespan now yields the singleton; `finally` is a no-op | No per-session close → no race |
| `_LazyDB.close()` idempotent + `AttributeError`-tolerant | Safe under double-call from atexit + any cleanup path; HTTP backend (no `close()`) doesn't blow up |
| `_emit_skill_safety_warnings()` de-duped via module flag | Stop spamming the journal + audit log on every SSE reconnect |

No signal handlers — they conflict with uvicorn's own SIGTERM handling. `atexit` is the right hook because it runs after Python's normal shutdown completes (the engine owns the SQLite handle exclusively at that point).

## Tests

`tests/test_server_singleton.py` — **6 new unit tests**:

1. Singleton identity across calls
2. Double-checked locking holds under 8-thread contention barrier
3. `atexit.register` fires exactly once (monkeypatched to count)
4. `close()` idempotent — 3× call ⇒ 1× inner close, `_db` nulled
5. `close()` tolerates engine without `close()` method (HTTP backend path)
6. Safety warnings emit exactly once across multiple lifespan entries

**Local: 121 tests pass** (the 6 new + 115 from v0.8.1). HTTP-backend parity test still green.

## Affects

SSE transport only. stdio is immune (lifespan runs exactly once per process) but the singleton change keeps stdio behavior identical — no regression.

## Migration

None required. Same env vars, same behavior, just no more racy close.

Thanks @blue-mtn-dog — second high-quality report in two days. The diagnosis was complete enough that the fix was almost mechanical.