### PR TITLE
v0.9.1: fix correct tool for engine v0.7.20+ signature — reason required, correction_note gone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.9.0"
+version = "0.9.1"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"

--- a/src/yantrikdb_mcp/http_backend.py
+++ b/src/yantrikdb_mcp/http_backend.py
@@ -185,16 +185,24 @@ class HttpBackend:
         result = self._post("/v1/forget", {"rid": rid})
         return result.get("found", False)
 
-    def correct(self, rid: str, new_text: str, *,
+    def correct(self, rid: str, reason: str, *,
+                new_text: str | None = None,
                 new_importance=None, new_valence=None,
-                correction_note=None) -> dict:
-        body: dict = {"rid": rid, "new_text": new_text}
+                metadata_merge: dict | None = None) -> dict:
+        """Engine v0.7.20+ correct signature (Issue #47): reason is required,
+        `correction_note` is gone, `new_text` is now optional. HTTP backend
+        mirrors the embedded shape."""
+        if not reason or not reason.strip():
+            raise ValueError("reason must be non-empty")
+        body: dict = {"rid": rid, "reason": reason}
+        if new_text is not None:
+            body["new_text"] = new_text
         if new_importance is not None:
             body["new_importance"] = new_importance
         if new_valence is not None:
             body["new_valence"] = new_valence
-        if correction_note:
-            body["correction_note"] = correction_note
+        if metadata_merge:
+            body["metadata_merge"] = metadata_merge
         return self._post("/v1/correct", body)
 
     def think(self, config=None) -> "ThinkResult":

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -308,38 +308,58 @@ def forget(
 @mcp.tool(annotations=ToolAnnotations(title="Correct", readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=False))
 def correct(
     rid: str,
-    new_text: str,
+    reason: str,
+    new_text: str | None = None,
     new_importance: float | None = None,
     new_valence: float | None = None,
-    correction_note: str | None = None,
+    metadata_merge: dict | None = None,
     ctx: Context = None,
 ) -> str:
-    """Correct an existing memory — tombstones the old one and creates a corrected version.
+    """Correct an existing memory in-place with a revision-history entry
+    (engine v0.7.20+, Issue #47).
 
     WHEN TO USE: When the user corrects a recalled fact.
     - "Actually, we're using Python 3.12, not 3.11" → correct the memory.
-    Preserves history and transfers entity relationships to the new memory.
+
+    Preserves history via an append-only revision entry keyed on `reason`.
+    Entity relationships stay attached to the same rid (in-place mutation,
+    not a tombstone+new-rid dance).
 
     Args:
         rid: The memory ID to correct.
-        new_text: The corrected text content.
+        reason: **Required** — why the correction was made. Non-empty.
+            Recorded on the revision-history entry so future recall +
+            audit can reconstruct why the memory changed.
+        new_text: Optional new text (pass None to keep existing).
         new_importance: Optional updated importance (0.0-1.0).
         new_valence: Optional updated valence (-1.0 to 1.0).
-        correction_note: Why the correction was made.
+        metadata_merge: Optional dict to merge into existing metadata
+            (None = keep as-is).
     """
-    if not new_text or not new_text.strip():
-        raise ToolError("new_text must be non-empty")
+    if not reason or not reason.strip():
+        raise ToolError("reason must be non-empty")
+    if new_text is not None and not new_text.strip():
+        raise ToolError("new_text may be omitted, but if provided must be non-empty")
 
     db = _get_db(ctx)
     try:
-        result = db.correct(rid, new_text, new_importance=new_importance,
-                            new_valence=new_valence, correction_note=correction_note)
+        result = db.correct(
+            rid,
+            reason.strip(),
+            new_text=(new_text.strip() if new_text else None),
+            metadata_merge=metadata_merge,
+            new_importance=new_importance,
+            new_valence=new_valence,
+        )
     except Exception as e:
         return _err(str(e), rid=rid)
+    # v0.7.20+ mutates in place: corrected_rid == rid. Return both for
+    # backward-compatible response shape.
     return json.dumps({
-        "original_rid": result["original_rid"],
-        "corrected_rid": result["corrected_rid"],
-        "original_tombstoned": result["original_tombstoned"],
+        "rid": result.get("corrected_rid") or rid,
+        "corrected_rid": result.get("corrected_rid") or rid,
+        "original_rid": result.get("original_rid") or rid,
+        "reason": reason.strip(),
     })
 
 
@@ -559,9 +579,16 @@ def memory(
         mem = db.get(rid)
         if mem is None:
             return _err("Memory not found", rid=rid)
-        result = db.correct(rid, mem["text"], new_importance=max(0.0, min(1.0, importance)),
-                            correction_note=f"Importance adjusted from {mem['importance']} to {importance}")
-        return json.dumps({"rid": result["corrected_rid"], "old_importance": mem["importance"],
+        # Engine v0.7.20+ signature: reason is required + first positional
+        # after rid; new_text is optional (we keep the existing text here
+        # since this action only mutates importance).
+        result = db.correct(
+            rid,
+            f"Importance adjusted from {mem['importance']} to {importance}",
+            new_importance=max(0.0, min(1.0, importance)),
+        )
+        corrected_rid = result.get("corrected_rid") or rid
+        return json.dumps({"rid": corrected_rid, "old_importance": mem["importance"],
                            "new_importance": importance, "status": "updated"})
 
     if action == "archive":

--- a/tests/test_new_tools_v090.py
+++ b/tests/test_new_tools_v090.py
@@ -363,3 +363,78 @@ def test_remember_draft_from_summary(mcp_proc):
     assert not is_err
     # Body shape varies by engine; just confirm non-empty dict
     assert isinstance(body, dict)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Regression: correct tool signature (v0.9.1 — engine v0.7.20+ change)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_correct_tool_accepts_reason_and_works_e2e(mcp_proc):
+    """v0.9.1 regression pin — engine v0.7.20 (Issue #47) made `reason`
+    required and removed `correction_note` on `db.correct()`. Prior to
+    v0.9.1 the MCP `correct` tool passed `correction_note=` and blew up
+    with `unexpected keyword argument 'correction_note'` for every user
+    on engine >=0.7.20. This test would have caught it: create a
+    memory, then correct it via the tool, then assert the result shape."""
+    # 1) Record a memory to correct
+    is_err, body = _unwrap(_call_tool(
+        mcp_proc, "remember", 200,
+        text="Python 3.11 is the target for the build.",
+        domain="architecture",
+    ))
+    assert not is_err, f"seed remember failed: {body}"
+    seed_rid = body["rid"]
+
+    # 2) Correct with the new-signature args (reason required)
+    is_err, body = _unwrap(_call_tool(
+        mcp_proc, "correct", 201,
+        rid=seed_rid,
+        reason="Switched from 3.11 to 3.12 after adopting new deps",
+        new_text="Python 3.12 is the target for the build.",
+    ))
+    assert not is_err, f"correct failed: {body}"
+    # Engine v0.7.20+ mutates in-place; the response includes corrected_rid
+    assert body.get("corrected_rid") is not None
+    assert body.get("reason", "").startswith("Switched")
+
+
+def test_correct_tool_reason_is_required(mcp_proc):
+    """Missing reason must fail loud (schema-level rejection) before the
+    engine sees the call — matches v0.7.20's contract."""
+    is_err, body = _unwrap(_call_tool(
+        mcp_proc, "remember", 210,
+        text="Any old memory",
+    ))
+    assert not is_err
+    rid = body["rid"]
+
+    is_err, body = _unwrap(_call_tool(
+        mcp_proc, "correct", 211,
+        rid=rid, reason="",  # empty — must reject
+        new_text="Doesn't matter",
+    ))
+    assert is_err
+    assert "reason" in str(body).lower()
+
+
+def test_memory_update_importance_uses_new_correct_signature(mcp_proc):
+    """The `memory(action="update_importance")` action calls `db.correct()`
+    internally. Before v0.9.1 it passed `correction_note=`, which would
+    have exploded on any engine >=0.7.20. This regression pins the
+    action against the new signature."""
+    is_err, body = _unwrap(_call_tool(
+        mcp_proc, "remember", 220,
+        text="A minor detail worth remembering.",
+        importance=0.4,
+    ))
+    assert not is_err
+    rid = body["rid"]
+
+    is_err, body = _unwrap(_call_tool(
+        mcp_proc, "memory", 221,
+        action="update_importance", rid=rid, importance=0.9,
+    ))
+    assert not is_err, f"update_importance failed: {body}"
+    assert body["new_importance"] == 0.9
+    assert body["status"] == "updated"


### PR DESCRIPTION
## The bug (in the wild right now)

yantrikdb-mcp v0.9.0 still calls `db.correct(rid, new_text, correction_note=...)`, but engine v0.7.20 (yantrikos/yantrikdb#47) made a breaking-change signature swap:

| | Before v0.7.20 | v0.7.20+ |
|---|---|---|
| `reason` | absent | **required** |
| `correction_note` | present (optional) | **removed** (folded into `reason`) |
| `new_text` | required (2nd positional) | optional (kwarg) |
| `metadata_merge` | absent | added |

Every `correct` call has been failing since the engine pin caught up with v0.7.20:

```
YantrikDB.correct() got an unexpected keyword argument 'correction_note'
```

Same regression silently hit `memory(action="update_importance")`, which internally calls `db.correct()`.

## Fixes

- **`tools.py correct` tool**: swap `correction_note` → `reason` (required), make `new_text` optional, add `metadata_merge` passthrough, update response shape to reflect in-place mutation
- **`tools.py memory(action="update_importance")`**: pass the note as `reason` positionally and drop the removed kwarg
- **`http_backend.py correct()`** stub: mirror the new signature

## Tests (+3, 138 pass total)

Three regression tests that would have caught the original bug on day one:

1. `test_correct_tool_accepts_reason_and_works_e2e` — end-to-end via JSON-RPC, seeds a memory, corrects it with the new args, asserts `corrected_rid` + `reason`
2. `test_correct_tool_reason_is_required` — empty reason must fail loud at the tool layer before hitting the engine
3. `test_memory_update_importance_uses_new_correct_signature` — covers the second internal call site that broke silently

## Discovery

Surfaced by @spranab's live yantrikdb-agi session hitting the error in production this morning (2026-07-10).

## Migration

None. Backward-compatible on the callable surface — the `correct` tool now has a required `reason` param instead of an optional `correction_note`, but no live caller was reaching the pre-v0.9.1 tool successfully anyway (it always errored).