### PR TITLE
mind: Add a startup signature self-check to the MCP server: at boot, validate that every MCP tool wrapper's forwarded kwargs match the underlying engine method signatures (inspect.signature), log a loud specific error naming tool+parameter on mismatch instead of failing later at call time, and add a regression test that catches a deliberately mismatched wrapper.

### DIFF
--- a/src/yantrikdb_mcp/server.py
+++ b/src/yantrikdb_mcp/server.py
@@ -1,11 +1,14 @@
 """FastMCP server definition with YantrikDB lifespan context."""
 
 import atexit
+import ast
+import inspect
 import logging
 import os
 import sys
 import threading
 import time
+import textwrap
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -217,6 +220,53 @@ def _emit_skill_safety_warnings() -> None:
         })
 
 
+def _validate_tool_signatures(engine_class, tools_module) -> None:
+    """Fail startup when a tool forwards an unknown engine keyword."""
+    mismatches = []
+    for tool_name, tool in vars(tools_module).items():
+        if tool_name.startswith("_") or not inspect.isfunction(tool):
+            continue
+        try:
+            tree = ast.parse(textwrap.dedent(inspect.getsource(tool)))
+        except (OSError, TypeError, IndentationError, SyntaxError):
+            continue
+
+        for call in ast.walk(tree):
+            if not (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and isinstance(call.func.value, ast.Name)
+                and call.func.value.id == "db"
+            ):
+                continue
+
+            method_name = call.func.attr
+            try:
+                signature = inspect.signature(getattr(engine_class, method_name))
+            except (AttributeError, TypeError, ValueError):
+                continue
+            accepts_kwargs = any(
+                p.kind == inspect.Parameter.VAR_KEYWORD
+                for p in signature.parameters.values()
+            )
+            if accepts_kwargs:
+                continue
+            for keyword in call.keywords:
+                if keyword.arg is not None and keyword.arg not in signature.parameters:
+                    mismatches.append((tool_name, method_name, keyword.arg))
+
+    for tool_name, method_name, parameter in mismatches:
+        log.error(
+            "MCP TOOL SIGNATURE MISMATCH: tool '%s' forwards parameter '%s' "
+            "but YantrikDB.%s() does not accept it",
+            tool_name, parameter, method_name,
+        )
+    if mismatches:
+        raise RuntimeError(
+            f"MCP tool signature validation failed with {len(mismatches)} mismatch(es)"
+        )
+
+
 # Process-singleton `_LazyDB`. Under SSE transport, FastMCP/uvicorn
 # enters the `lifespan` context once per client session. The v0.8.1
 # implementation constructed a fresh `_LazyDB` on every entry and
@@ -257,6 +307,7 @@ async def lifespan(app: FastMCP):
     session yields the same `_LazyDB` instance. Close happens once via
     `atexit`, not per-session. See yantrikos/yantrikdb-mcp#11.
     """
+    _validate_tool_signatures(YantrikDB, _tools)
     lazy = _get_lazy_singleton()
     log.info("YantrikDB MCP server started (model loads on first use)")
     _emit_skill_safety_warnings()

--- a/tests/test_tool_signatures.py
+++ b/tests/test_tool_signatures.py
@@ -1,0 +1,29 @@
+"""Startup validation for MCP wrapper/engine signature drift."""
+
+from types import ModuleType
+
+import pytest
+
+from yantrikdb_mcp.server import _validate_tool_signatures
+
+
+def deliberately_mismatched_wrapper(ctx=None):
+    db = ctx
+    return db.correct("rid", correction_note="outdated wrapper")
+
+
+class _Engine:
+    def correct(self, rid, reason):
+        pass
+
+
+def test_signature_check_names_tool_and_forwarded_parameter(caplog):
+    tools = ModuleType("deliberately_mismatched_tools")
+    tools.deliberately_mismatched_wrapper = deliberately_mismatched_wrapper
+
+    with pytest.raises(RuntimeError, match="1 mismatch"):
+        _validate_tool_signatures(_Engine, tools)
+
+    assert "tool 'deliberately_mismatched_wrapper'" in caplog.text
+    assert "parameter 'correction_note'" in caplog.text
+    assert "YantrikDB.correct()" in caplog.text


### PR DESCRIPTION
**Generated by yantrik-mind** — research wing proposal; implementation by OpenAI Codex CLI; pushed via the yantrikdb account. Human review and merge required; nothing auto-merges.

**Goal:** Add a startup signature self-check to the MCP server: at boot, validate that every MCP tool wrapper's forwarded kwargs match the underlying engine method signatures (inspect.signature), log a loud specific error naming tool+parameter on mismatch instead of failing later at call time, and add a regression test that catches a deliberately mismatched wrapper.

**Research trail:** Lived outage 2026-07-10: the correct() tool was broken for weeks (engine signature drift, 'unexpected keyword argument correction_note' surfaced only at call time to a live client); maintainer fixed the instance same-day in v0.9.1 (bfda0ef) — this PR fixes the defect CLASS so the next drift is caught at boot.

**Base:** `bfda0ef9c4265fd9b06959356f80f1c652bac828` on `main`
**Verification:** owner-declared `python3 -m venv .venv && .venv/bin/pip install -q -e . pytest && .venv/bin/python -m pytest tests -q` passed locally (credential-free env)

*Prediction on record: p(merge within 14d) = 0.7 — graded either way in the mind's Judgment Ledger.*