### PR TITLE
v0.12.0: support both mcp SDK lines (1.x and 2.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,21 @@ on:
 
 jobs:
   unit:
-    name: Unit tests
+    name: Unit tests (py${{ matrix.python-version }}, ${{ matrix.mcp-line }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         # 3.14 is engine-supported since yantrikdb v0.7.11 — the engine
         # wheel matrix builds against it, so we test against it too.
         python-version: ["3.10", "3.12", "3.14"]
+        # BOTH supported SDK majors. mcp 2.0.0 removed `mcp.server.fastmcp`
+        # and additionally REFUSES Context injection on static resources —
+        # a behavioural divergence, not just a symbol move, and one that only
+        # surfaces by actually running against 2.x. `yantrikdb_mcp._compat`
+        # papers over the symbol moves; this axis is what keeps that support
+        # honest instead of letting it rot into a claim nobody checks.
+        mcp-line: ["mcp1", "mcp2"]
     steps:
       - uses: actions/checkout@v4
 
@@ -28,16 +36,42 @@ jobs:
           python -m pip install -U pip
           pip install -e ".[dev,onnx]"
 
+      # Installed AFTER the package so this pin wins over the range resolved
+      # above. Each leg then asserts it actually got the line it asked for —
+      # a silently-wrong resolve would otherwise make one leg a duplicate of
+      # the other and quietly halve the coverage.
+      - name: Pin MCP SDK line (${{ matrix.mcp-line }})
+        run: |
+          if [ "${{ matrix.mcp-line }}" = "mcp1" ]; then
+            pip install -U "mcp[cli]>=1.2.0,<2.0.0"
+          else
+            pip install -U "mcp[cli]>=2.0.0,<3.0.0"
+          fi
+
+      - name: Verify the intended SDK line is what got installed
+        run: |
+          python - <<'EOF'
+          from yantrikdb_mcp._compat import MCP_MAJOR, sdk_line
+          want = 1 if "${{ matrix.mcp-line }}" == "mcp1" else 2
+          print(f"resolved {sdk_line()} (want major {want})")
+          assert MCP_MAJOR == want, f"expected mcp {want}.x, got {sdk_line()}"
+          EOF
+
       - name: Run unit tests (excluding e2e)
         run: pytest -q --ignore=tests/test_e2e_mcp.py
 
   e2e:
-    name: E2E (${{ matrix.backend }} backend)
+    name: E2E (${{ matrix.backend }} backend, ${{ matrix.mcp-line }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         backend: [bundled, onnx, multilingual]
+        # The e2e suite drives a real server over stdio JSON-RPC, so it is
+        # the only place the SDK's actual wire behaviour (tools/list shape,
+        # resource registration, isError envelopes) is exercised. Both lines
+        # must pass it, not just import successfully.
+        mcp-line: ["mcp1", "mcp2"]
     steps:
       - uses: actions/checkout@v4
 
@@ -67,6 +101,23 @@ jobs:
         run: |
           python -m pip install -U pip
           pip install -e ".[dev]"
+
+      - name: Pin MCP SDK line (${{ matrix.mcp-line }})
+        run: |
+          if [ "${{ matrix.mcp-line }}" = "mcp1" ]; then
+            pip install -U "mcp[cli]>=1.2.0,<2.0.0"
+          else
+            pip install -U "mcp[cli]>=2.0.0,<3.0.0"
+          fi
+
+      - name: Verify the intended SDK line is what got installed
+        run: |
+          python - <<'EOF'
+          from yantrikdb_mcp._compat import MCP_MAJOR, sdk_line
+          want = 1 if "${{ matrix.mcp-line }}" == "mcp1" else 2
+          print(f"resolved {sdk_line()} (want major {want})")
+          assert MCP_MAJOR == want, f"expected mcp {want}.x, got {sdk_line()}"
+          EOF
 
       - name: Pre-cache HuggingFace MiniLM (onnx only)
         if: matrix.backend == 'onnx'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,11 +11,13 @@ jobs:
   # Re-run the full test matrix on the tagged commit before we ship.
   # We don't blindly trust that whoever cut the release first checked CI on main.
   unit:
-    name: Unit tests
+    name: Unit tests (py${{ matrix.python-version }}, ${{ matrix.mcp-line }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.12", "3.14"]
+        mcp-line: ["mcp1", "mcp2"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -25,15 +27,35 @@ jobs:
       - run: |
           python -m pip install -U pip
           pip install -e ".[dev,onnx]"
+      # Both supported SDK majors are gated before we ship. Installed AFTER
+      # the package so the pin wins, and asserted so a bad resolve can't
+      # silently turn this leg into a duplicate of the other one.
+      - name: Pin MCP SDK line (${{ matrix.mcp-line }})
+        run: |
+          if [ "${{ matrix.mcp-line }}" = "mcp1" ]; then
+            pip install -U "mcp[cli]>=1.2.0,<2.0.0"
+          else
+            pip install -U "mcp[cli]>=2.0.0,<3.0.0"
+          fi
+
+      - name: Verify the intended SDK line is what got installed
+        run: |
+          python - <<'EOF'
+          from yantrikdb_mcp._compat import MCP_MAJOR, sdk_line
+          want = 1 if "${{ matrix.mcp-line }}" == "mcp1" else 2
+          print(f"resolved {sdk_line()} (want major {want})")
+          assert MCP_MAJOR == want, f"expected mcp {want}.x, got {sdk_line()}"
+          EOF
       - run: pytest -q --ignore=tests/test_e2e_mcp.py
 
   e2e:
-    name: E2E (${{ matrix.backend }} backend)
+    name: E2E (${{ matrix.backend }} backend, ${{ matrix.mcp-line }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         backend: [bundled, onnx, multilingual]
+        mcp-line: ["mcp1", "mcp2"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -63,6 +85,26 @@ jobs:
           python -c "from huggingface_hub import hf_hub_download; \
                      hf_hub_download('sentence-transformers/all-MiniLM-L6-v2', 'onnx/model.onnx'); \
                      hf_hub_download('sentence-transformers/all-MiniLM-L6-v2', 'tokenizer.json')"
+
+      # Both supported SDK majors are gated before we ship. Installed AFTER
+      # the package so the pin wins, and asserted so a bad resolve can't
+      # silently turn this leg into a duplicate of the other one.
+      - name: Pin MCP SDK line (${{ matrix.mcp-line }})
+        run: |
+          if [ "${{ matrix.mcp-line }}" = "mcp1" ]; then
+            pip install -U "mcp[cli]>=1.2.0,<2.0.0"
+          else
+            pip install -U "mcp[cli]>=2.0.0,<3.0.0"
+          fi
+
+      - name: Verify the intended SDK line is what got installed
+        run: |
+          python - <<'EOF'
+          from yantrikdb_mcp._compat import MCP_MAJOR, sdk_line
+          want = 1 if "${{ matrix.mcp-line }}" == "mcp1" else 2
+          print(f"resolved {sdk_line()} (want major {want})")
+          assert MCP_MAJOR == want, f"expected mcp {want}.x, got {sdk_line()}"
+          EOF
       - name: Run e2e
         env:
           YANTRIKDB_EMBEDDER: ${{ matrix.backend }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.11.0"
+version = "0.12.0"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"
@@ -77,10 +77,12 @@ dependencies = [
     # broken the published v0.10.0 for new installs — an unbounded pin on a
     # hard runtime dependency is a release that silently re-ships itself
     # every time upstream cuts a major.
-    # Verified before bounding: mcp 1.29.0 (top of the 1.x line) still
-    # exports FastMCP, ToolError, and ToolAnnotations. Widen to 2.x only
-    # after the FastMCP-2 import surface is ported and contract-tested.
-    "mcp[cli]>=1.2.0,<2.0.0",
+    # v0.12.0 WIDENS to <3.0.0: the 2.x import surface is now ported behind
+    # `yantrikdb_mcp._compat`, and BOTH lines are exercised in CI (publish.yml
+    # runs the unit suite against mcp 1.x and mcp 2.x). The ceiling stays —
+    # it moves to the next major only when that major is actually tested,
+    # never speculatively.
+    "mcp[cli]>=1.2.0,<3.0.0",
     "click>=8.0.0",
     "requests>=2.28.0",
 ]

--- a/src/yantrikdb_mcp/__init__.py
+++ b/src/yantrikdb_mcp/__init__.py
@@ -20,7 +20,12 @@ def _cli_arg(name):
 def main():
     """Entry point for the yantrikdb-mcp console script."""
     if "--version" in sys.argv or "-V" in sys.argv:
-        print(f"yantrikdb-mcp {__version__}")
+        # Report the SDK line too: this package supports both mcp 1.x and
+        # 2.x, and "which line am I actually on" is the first question in
+        # any import-error bug report.
+        from ._compat import sdk_line
+
+        print(f"yantrikdb-mcp {__version__} ({sdk_line()})")
         sys.exit(0)
 
     if "--help" in sys.argv or "-h" in sys.argv:

--- a/src/yantrikdb_mcp/_compat.py
+++ b/src/yantrikdb_mcp/_compat.py
@@ -1,0 +1,68 @@
+"""MCP SDK compatibility layer — supports both the 1.x and 2.x SDK lines.
+
+WHY THIS EXISTS
+---------------
+mcp 2.0.0 removed `mcp.server.fastmcp`. Every symbol this package imports at
+module scope moved, so `import yantrikdb_mcp` raised ModuleNotFoundError on
+the new SDK — and because the dependency was pinned `>=1.2.0` with no
+ceiling, already-published releases silently re-shipped themselves broken the
+day 2.0.0 landed (see tests/test_dependency_pins.py).
+
+The migration turned out to be a SYMBOL-LOCATION change, not a semantic one.
+Verified empirically against mcp 2.0.0 before this module was written:
+
+  - `MCPServer(name, instructions=..., lifespan=...)` accepts the same
+    arguments we pass to `FastMCP`
+  - `@server.tool(annotations=ToolAnnotations(...))` keeps the same shape,
+    and the annotations survive to the wire in tools/list
+  - a `lifespan` async-context-manager yielding a dict is still reachable as
+    `ctx.request_context.lifespan_context`
+  - `ToolError` still renders as `isError: true` on the result envelope
+  - `mcp.types.ToolAnnotations` did not move at all
+  - `.run(transport="stdio"|"sse"|"streamable-http")` is unchanged
+
+Because the semantics match, ONE codebase can serve both lines: this module
+resolves the symbols and the rest of the package imports them from here.
+Nothing else in the package may import from `mcp.server.*` directly — the
+dependency-pin suite asserts that, so a future contributor can't reintroduce
+a version-specific import path that only fails on the other line.
+
+WHICH LINE AM I ON?
+-------------------
+`MCP_MAJOR` is 1 or 2, resolved by probing the import, never by parsing a
+version string. That is the same discipline the engine contract suites use:
+two builds can report the same version and behave differently, so the probe
+is the truth and the version is a backstop.
+"""
+from __future__ import annotations
+
+# ToolAnnotations lives in mcp.types on BOTH lines — no shim needed, but it's
+# re-exported here so callers have exactly one import site for MCP symbols.
+from mcp.types import ToolAnnotations
+
+try:
+    # ── mcp 2.x ──
+    from mcp.server import MCPServer as _ServerClass
+    from mcp.server.mcpserver import Context
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    MCP_MAJOR = 2
+except ImportError:  # pragma: no cover - exercised on the 1.x CI leg
+    # ── mcp 1.x ──
+    # FastMCP is the 1.x name for the same object; alias it so the rest of
+    # the package speaks one vocabulary regardless of the installed line.
+    from mcp.server.fastmcp import Context, FastMCP as _ServerClass
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    MCP_MAJOR = 1
+
+# The canonical name used throughout this package. On 1.x this IS FastMCP;
+# on 2.x it IS MCPServer. Callers must not care which.
+MCPServer = _ServerClass
+
+__all__ = ["MCPServer", "Context", "ToolError", "ToolAnnotations", "MCP_MAJOR"]
+
+
+def sdk_line() -> str:
+    """Human-readable SDK line, for --help / diagnostics."""
+    return f"mcp {MCP_MAJOR}.x"

--- a/src/yantrikdb_mcp/resources.py
+++ b/src/yantrikdb_mcp/resources.py
@@ -1,41 +1,61 @@
-"""MCP resource definitions for YantrikDB."""
+"""MCP resource definitions for YantrikDB.
+
+STATIC vs TEMPLATED resources and `Context`
+-------------------------------------------
+mcp 2.x refuses to register a STATIC resource (one whose URI has no template
+variables) whose handler declares a `Context` parameter:
+
+    ValueError: Resource 'yantrikdb://stats' has no URI template variables,
+    but the handler declares a Context parameter. Context injection for
+    static resources is not supported.
+
+That is a real behavioural divergence from 1.x, not a symbol move — it was
+caught by running the suite against mcp 2.0.0 rather than by reading the
+diff. Static resources here therefore reach the engine through the
+process-singleton `_get_lazy_singleton()` instead of through the request
+context. That is not a workaround: the singleton is the *intended* owner of
+the handle (yantrikos/yantrikdb-mcp#11), the lifespan context merely hands
+out the same object, and a resource that needs no per-request state has no
+reason to demand one. The result registers identically on both SDK lines.
+
+Templated resources (e.g. `yantrikdb://memory/{rid}`) may still take
+`Context` on both lines, but use the same accessor for consistency.
+"""
 
 import json
 
-from mcp.server.fastmcp import Context
-
-from .server import mcp
+from .server import _get_lazy_singleton, mcp
 
 
-def _get_db(ctx: Context):
-    lc = ctx.request_context.lifespan_context
-    lazy = lc["lazy"]
-    return lazy.db
+def _db():
+    """The process-singleton engine handle.
+
+    Deliberately not `ctx.request_context.lifespan_context` — see the module
+    docstring. The lifespan yields this very object, so both paths return the
+    same instance; this one just doesn't require a Context to exist.
+    """
+    return _get_lazy_singleton().db
 
 
 @mcp.resource("yantrikdb://stats")
-def stats_resource(ctx: Context = None) -> str:
+def stats_resource() -> str:
     """Current YantrikDB engine statistics — memory counts, entities, conflicts, patterns."""
-    db = _get_db(ctx)
-    stats = db.stats()
-    return json.dumps(stats, indent=2)
+    return json.dumps(_db().stats(), indent=2)
 
 
 @mcp.resource("yantrikdb://memory/{rid}")
-def memory_resource(rid: str, ctx: Context = None) -> str:
+def memory_resource(rid: str) -> str:
     """A specific memory record by ID."""
-    db = _get_db(ctx)
-    mem = db.get(rid)
+    mem = _db().get(rid)
     if mem is None:
         return json.dumps({"error": "Memory not found", "rid": rid})
     return json.dumps(mem, indent=2)
 
 
 @mcp.resource("yantrikdb://health")
-def health_resource(ctx: Context = None) -> str:
+def health_resource() -> str:
     """Server health status — use to verify the memory system is operational."""
-    db = _get_db(ctx)
-    stats = db.stats()
+    stats = _db().stats()
     return json.dumps({
         "status": "ok",
         # Engine key is `active_memories` (both embedded dict and the HTTP

--- a/src/yantrikdb_mcp/server.py
+++ b/src/yantrikdb_mcp/server.py
@@ -1,4 +1,9 @@
-"""FastMCP server definition with YantrikDB lifespan context."""
+"""MCP server definition with YantrikDB lifespan context.
+
+Runs on both SDK lines: the server object is `FastMCP` on mcp 1.x and
+`MCPServer` on mcp 2.x, resolved by `._compat`. See that module for the
+verified-equivalent semantics.
+"""
 
 import atexit
 import logging
@@ -9,7 +14,7 @@ import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from mcp.server.fastmcp import FastMCP
+from ._compat import MCPServer
 
 # Configure logging to stderr (stdout is reserved for MCP JSON-RPC)
 logging.basicConfig(stream=sys.stderr, level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -261,7 +266,7 @@ def _get_lazy_singleton() -> "_LazyDB":
 
 
 @asynccontextmanager
-async def lifespan(app: FastMCP):
+async def lifespan(app: MCPServer):
     """Provide a process-singleton YantrikDB context.
 
     Under stdio transport this runs once. Under SSE transport FastMCP
@@ -280,7 +285,7 @@ async def lifespan(app: FastMCP):
         pass
 
 
-mcp = FastMCP("yantrikdb", instructions=INSTRUCTIONS, lifespan=lifespan)
+mcp = MCPServer("yantrikdb", instructions=INSTRUCTIONS, lifespan=lifespan)
 
 # Import tools and resources so they register with the server
 from . import resources as _resources  # noqa: F401, E402

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -5,9 +5,7 @@ import logging
 import os
 import time
 
-from mcp.server.fastmcp import Context
-from mcp.server.fastmcp.exceptions import ToolError
-from mcp.types import ToolAnnotations
+from ._compat import Context, ToolAnnotations, ToolError
 
 from .server import mcp
 

--- a/tests/test_dependency_pins.py
+++ b/tests/test_dependency_pins.py
@@ -69,20 +69,58 @@ def test_runtime_dependency_has_upper_bound(spec: str) -> None:
     )
 
 
-def test_mcp_pin_excludes_the_fastmcp_removal() -> None:
-    """Specifically pin the regression: mcp 2.x removed mcp.server.fastmcp,
-    which server.py imports at module scope."""
+def test_mcp_pin_is_bounded_at_the_next_untested_major() -> None:
+    """v0.11.0 pinned <2.0.0 because 2.x removed `mcp.server.fastmcp`. v0.12.0
+    ports that surface behind `_compat`, so the ceiling moves to <3.0.0 — the
+    next major we have NOT tested. The ceiling moves only when a major is
+    actually exercised in CI, never speculatively."""
     spec = next((d for d in _runtime_deps() if _name_of(d) == "mcp"), None)
     assert spec is not None, "mcp is a hard runtime dependency and must be declared"
-    assert "<2.0.0" in spec.replace(" ", ""), (
-        f"mcp pin {spec!r} must exclude 2.x until the FastMCP-2 import surface "
-        f"is ported and contract-tested — 2.0.0 removed `mcp.server.fastmcp`."
+    assert "<3.0.0" in spec.replace(" ", ""), (
+        f"mcp pin {spec!r} must stop at the first UNTESTED major. Both 1.x and "
+        f"2.x are supported via yantrikdb_mcp._compat and covered in CI; 3.x is "
+        f"not, so it must stay excluded until it is."
     )
 
 
-def test_the_imports_the_server_actually_needs_are_importable() -> None:
+def test_the_symbols_the_server_actually_needs_resolve() -> None:
     """The rejection surface for this whole class of failure: not 'is a version
-    installed' but 'do the symbols server.py imports at module scope exist'."""
-    from mcp.server.fastmcp import FastMCP  # noqa: F401
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: F401
-    from mcp.types import ToolAnnotations  # noqa: F401
+    installed' but 'do the symbols the server imports at module scope exist'.
+
+    Goes through `_compat`, which is the only place allowed to know which SDK
+    line is installed."""
+    from yantrikdb_mcp._compat import (  # noqa: F401
+        MCP_MAJOR,
+        Context,
+        MCPServer,
+        ToolAnnotations,
+        ToolError,
+    )
+
+    assert MCP_MAJOR in (1, 2), f"unexpected MCP SDK line: {MCP_MAJOR}"
+    assert callable(MCPServer)
+    assert issubclass(ToolError, Exception)
+
+
+def test_no_module_bypasses_the_compat_layer() -> None:
+    """A direct `from mcp.server.fastmcp import ...` anywhere outside _compat
+    silently breaks the other SDK line — and would only be caught on whichever
+    CI leg happens to run it. Enforce the single import site structurally."""
+    src = pathlib.Path(__file__).resolve().parents[1] / "src" / "yantrikdb_mcp"
+    offenders: list[str] = []
+    for py in src.glob("*.py"):
+        if py.name == "_compat.py":
+            continue
+        for i, line in enumerate(py.read_text(encoding="utf-8").splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            # mcp.types is stable across both majors; the server/* tree is not.
+            if re.search(r"\bfrom\s+mcp\.server[.\s]|\bimport\s+mcp\.server\b", stripped):
+                offenders.append(f"{py.name}:{i}: {stripped}")
+    assert not offenders, (
+        "these modules import from `mcp.server.*` directly instead of going "
+        "through yantrikdb_mcp._compat — that path moved between SDK majors "
+        "and will break one of the two supported lines:\n  "
+        + "\n  ".join(offenders)
+    )

--- a/tests/test_mcp_compat.py
+++ b/tests/test_mcp_compat.py
@@ -1,0 +1,115 @@
+"""`_compat` must resolve to the SDK line that is ACTUALLY installed.
+
+A compat shim that imports successfully but silently picked the wrong branch
+is worse than no shim: every downstream symbol would still resolve, and the
+mismatch would only surface as strange runtime behaviour on one of the two
+lines. So these tests cross-check the shim's verdict against an independent
+probe of the environment, rather than trusting `MCP_MAJOR` on its own.
+"""
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from yantrikdb_mcp._compat import (
+    MCP_MAJOR,
+    Context,
+    MCPServer,
+    ToolAnnotations,
+    ToolError,
+    sdk_line,
+)
+
+
+def _fastmcp_present() -> bool:
+    """Independent probe: does the 1.x module tree exist in this env?"""
+    try:
+        return importlib.util.find_spec("mcp.server.fastmcp") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def test_major_matches_an_independent_probe() -> None:
+    """The shim's verdict must agree with the environment, not just be
+    self-consistent."""
+    expected = 1 if _fastmcp_present() else 2
+    assert MCP_MAJOR == expected, (
+        f"_compat resolved {sdk_line()} but mcp.server.fastmcp "
+        f"{'IS' if _fastmcp_present() else 'is NOT'} importable — the shim "
+        f"picked the wrong branch."
+    )
+
+
+def test_all_exported_symbols_are_usable() -> None:
+    assert MCP_MAJOR in (1, 2)
+    assert callable(MCPServer), "MCPServer must be constructible"
+    assert issubclass(ToolError, Exception)
+    assert Context is not None
+    # ToolAnnotations is a pydantic model on both lines; the server passes
+    # these exact fields, so a rename here would break every tool's metadata.
+    for field in ("title", "readOnlyHint", "destructiveHint",
+                  "idempotentHint", "openWorldHint"):
+        ToolAnnotations(**{field: True} if field != "title" else {"title": "x"})
+
+
+def test_server_object_is_the_line_appropriate_class() -> None:
+    """On 1.x this must be FastMCP; on 2.x it must be MCPServer. Guards
+    against the shim aliasing something plausible-but-wrong."""
+    if MCP_MAJOR == 1:
+        from mcp.server.fastmcp import FastMCP
+
+        assert MCPServer is FastMCP
+    else:
+        from mcp.server import MCPServer as Real
+
+        assert MCPServer is Real
+
+
+def test_the_live_server_object_was_built_from_the_shim() -> None:
+    """End-to-end: the module-level server really is an instance of the
+    class the shim resolved."""
+    from yantrikdb_mcp.server import mcp as live
+
+    assert isinstance(live, MCPServer)
+
+
+def test_static_resources_declare_no_context_parameter() -> None:
+    """mcp 2.x REFUSES to register a static resource whose handler takes a
+    Context, and the failure is at import time — it takes down the whole
+    server, not just that resource.
+
+    This is the divergence that the symbol-level shim could not paper over,
+    so pin it: any static (non-templated) resource handler must be
+    Context-free. Templated resources are exempt — 2.x allows Context there.
+    """
+    import inspect
+
+    from yantrikdb_mcp import resources as res
+
+    offenders = []
+    for name, fn in vars(res).items():
+        if not callable(fn) or name.startswith("_"):
+            continue
+        if not name.endswith("_resource"):
+            continue
+        params = inspect.signature(fn).parameters
+        has_ctx = any(
+            p.annotation is Context or getattr(p.annotation, "__name__", "") == "Context"
+            for p in params.values()
+        )
+        # A handler with no non-ctx params is bound to a static URI here.
+        templated = any(p.name != "ctx" for p in params.values())
+        if has_ctx and not templated:
+            offenders.append(name)
+    assert not offenders, (
+        f"static resource handlers must not declare Context — mcp 2.x refuses "
+        f"to register them and the server dies at import: {offenders}"
+    )
+
+
+@pytest.mark.skipif(MCP_MAJOR != 2, reason="2.x-specific guard")
+def test_no_static_resource_context_regression_on_2x() -> None:
+    """On 2.x, importing the package at all proves static-resource
+    registration succeeded — this is the canary for that whole class."""
+    import yantrikdb_mcp.resources  # noqa: F401


### PR DESCRIPTION
`mcp 2.0.0` removed `mcp.server.fastmcp`. **v0.11.0** bounded the pin at `<2.0.0` to stop shipping broken installs; **this release ports the surface**, so users aren't stranded on an SDK line upstream has moved past.

One codebase now serves both majors, and **both are gated in CI**.

## What actually changed in 2.x

Probed empirically against `mcp 2.0.0` — not read off a changelog:

| 1.x | 2.x |
|---|---|
| `mcp.server.fastmcp.FastMCP` | `mcp.server.MCPServer` |
| `mcp.server.fastmcp.Context` | `mcp.server.mcpserver.Context` |
| `mcp.server.fastmcp.exceptions.ToolError` | `mcp.server.mcpserver.exceptions.ToolError` |
| `mcp.types.ToolAnnotations` | unchanged |

Semantics that are **identical**: lifespan dict, `ctx.request_context.lifespan_context`, annotations passthrough to `tools/list`, `ToolError` → `isError: true`, `.run(transport=...)`.

**One real divergence**, found only by running the suite against 2.0.0 rather than by reading the diff: 2.x **refuses to register a static resource whose handler declares a `Context`** — and it fails at *import* time, taking down the whole server rather than just that resource.

## Changes

- **`_compat.py`** — the single import site for MCP symbols. Resolves by **probing the import, never parsing a version string** (same discipline as the engine contract suites, where two builds reporting one version behaved differently). Exposes `MCP_MAJOR` and `sdk_line()`.
- **`resources.py`** — static resources (`yantrikdb://stats`, `yantrikdb://health`) no longer take a `Context`; they reach the engine via the process-singleton `_get_lazy_singleton()`. Not a workaround: the singleton is the intended owner of the handle (#11), the lifespan hands out that same object, and a resource needing no per-request state shouldn't demand one.
- **Pin** `mcp[cli]` ceiling `<2.0.0` → `<3.0.0`. It moves *only* because 2.x is now exercised in CI. The next major stays excluded until tested — never speculatively.
- **CI + publish** — new `mcp-line` axis (`mcp1`/`mcp2`) on **unit and e2e**, so both lines are proven over real stdio JSON-RPC before anything ships. Each leg installs its pin *after* the package and then **asserts the resolved major**, because a silently-wrong resolve would make one leg a duplicate of the other and quietly halve coverage.
- `--version` now reports the active line (`yantrikdb-mcp 0.12.0 (mcp 2.x)`) — "which line am I on" is the first question in any import-error report.

## Tests — 214 passed on mcp 1.x, 214 passed on mcp 2.x

- **`test_mcp_compat.py`** — cross-checks the shim's verdict against an **independent probe** of the environment (a shim that imports fine but picked the wrong branch is worse than no shim), asserts the live server object is an instance of the resolved class, and pins the static-resource/`Context` rule the symbol-level shim couldn't paper over.
- **`test_dependency_pins.py`** — ceiling test updated to the next untested major, plus a guard that **no module outside `_compat` imports from `mcp.server.*`** directly; that path moved between majors and a stray import would only fail on whichever CI leg happened to run it.

Dogfooded on 2.x over real JSON-RPC: 20 tools advertised, static resources register and read, `remember` → `recall` round-trips.