### PR TITLE
v0.12.1: fix SSE / streamable-http startup on mcp 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.12.0"
+version = "0.12.1"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"

--- a/src/yantrikdb_mcp/__init__.py
+++ b/src/yantrikdb_mcp/__init__.py
@@ -75,17 +75,13 @@ def _run_network(transport: str):
     host = _cli_arg("--host") or "0.0.0.0"
     port = int(_cli_arg("--port") or "8420")
 
-    mcp.settings.host = host
-    mcp.settings.port = port
-    mcp.settings.transport_security.enable_dns_rebinding_protection = False
-    mcp.settings.transport_security.allowed_hosts = ["*"]
-    mcp.settings.transport_security.allowed_origins = ["*"]
+    # Host/transport-security configuration moved between SDK majors: 1.x
+    # mutates server.settings, while 2.x has no such fields and takes them as
+    # arguments to the app factory. `_compat.build_network_app` owns that
+    # divergence — see its docstring.
+    from ._compat import build_network_app
 
-    # Build the ASGI app
-    if transport == "sse":
-        app = mcp.sse_app()
-    else:
-        app = mcp.streamable_http_app()
+    app = build_network_app(mcp, transport, host, port)
 
     # Wrap with bearer token auth if configured
     api_key = os.environ.get("YANTRIKDB_API_KEY")

--- a/src/yantrikdb_mcp/_compat.py
+++ b/src/yantrikdb_mcp/_compat.py
@@ -60,9 +60,69 @@ except ImportError:  # pragma: no cover - exercised on the 1.x CI leg
 # on 2.x it IS MCPServer. Callers must not care which.
 MCPServer = _ServerClass
 
-__all__ = ["MCPServer", "Context", "ToolError", "ToolAnnotations", "MCP_MAJOR"]
+__all__ = [
+    "MCPServer",
+    "Context",
+    "ToolError",
+    "ToolAnnotations",
+    "MCP_MAJOR",
+    "build_network_app",
+    "sdk_line",
+]
 
 
 def sdk_line() -> str:
     """Human-readable SDK line, for --help / diagnostics."""
     return f"mcp {MCP_MAJOR}.x"
+
+
+def build_network_app(server, transport: str, host: str, port: int):
+    """Build the ASGI app for `sse` / `streamable-http` on either SDK line.
+
+    THE SECOND REAL DIVERGENCE between the majors, and the one that actually
+    bites deployments rather than tests:
+
+      1.x  configuration is MUTABLE STATE on the server —
+             server.settings.host = ...
+             server.settings.transport_security.allowed_hosts = [...]
+           then `server.sse_app()` reads it back.
+
+      2.x  `Settings` has NO host/port/transport_security fields at all;
+           assigning one raises `ValueError: "Settings" object has no field
+           "host"`. Host and security are ARGUMENTS to the app factory:
+             server.sse_app(host=..., transport_security=...)
+
+    So the 1.x code path doesn't merely misconfigure on 2.x — it raises, and
+    the server never starts. That is invisible to a stdio test suite, which is
+    exactly how it shipped in v0.12.0: every e2e case drives stdio, while the
+    deployed SSE servers take this path. Fixed in v0.12.1, with
+    `tests/test_network_transport_compat.py` covering both lines.
+
+    TransportSecuritySettings itself is identical on both majors — only the
+    place you attach it moved.
+
+    Binding note: uvicorn is what actually binds host:port (see
+    `_run_network`). On 1.x the settings assignment additionally feeds the
+    SDK's own URL construction, so it is still set there for fidelity.
+    """
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    # This server is deliberately permissive: it is normally reached over a
+    # LAN/tunnel and fronted by bearer-token auth (see auth.BearerTokenMiddleware),
+    # not by host/origin allowlisting.
+    security = TransportSecuritySettings(
+        enable_dns_rebinding_protection=False,
+        allowed_hosts=["*"],
+        allowed_origins=["*"],
+    )
+
+    if MCP_MAJOR == 1:
+        server.settings.host = host
+        server.settings.port = port
+        server.settings.transport_security = security
+        return server.sse_app() if transport == "sse" else server.streamable_http_app()
+
+    # 2.x — pass configuration in rather than mutating settings.
+    if transport == "sse":
+        return server.sse_app(host=host, transport_security=security)
+    return server.streamable_http_app(host=host, transport_security=security)

--- a/tests/test_network_transport_compat.py
+++ b/tests/test_network_transport_compat.py
@@ -1,0 +1,79 @@
+"""The SSE / streamable-http path must build on BOTH SDK lines.
+
+WHY THIS FILE EXISTS
+--------------------
+v0.12.0 shipped dual mcp 1.x/2.x support with a 12-leg CI matrix — and still
+broke every NETWORK deployment on 2.x, because every e2e case drives *stdio*.
+The network path was never executed on either line.
+
+The defect: 1.x configures the server by MUTATING `server.settings.host`,
+`server.settings.transport_security.*`. On 2.x `Settings` has no such fields,
+so the assignment raises
+
+    ValueError: "Settings" object has no field "host"
+
+i.e. the server does not start at all. Silent to a stdio suite; fatal to the
+actual deployments, which run SSE behind bearer auth.
+
+These tests build the ASGI app the way `_run_network` does, on whichever line
+is installed. Both CI legs run them, so the pair is covered.
+"""
+from __future__ import annotations
+
+import pytest
+
+from yantrikdb_mcp._compat import MCP_MAJOR, build_network_app, sdk_line
+
+
+@pytest.mark.parametrize("transport", ["sse", "streamable-http"])
+def test_network_app_builds(transport: str) -> None:
+    """The exact call `_run_network` makes. On 2.x this raised ValueError
+    before v0.12.1 and the process died before uvicorn ever bound."""
+    from yantrikdb_mcp.server import mcp
+
+    app = build_network_app(mcp, transport, "0.0.0.0", 8420)
+    assert app is not None, f"{transport} app must build on {sdk_line()}"
+    # Starlette ASGI apps are callable with (scope, receive, send).
+    assert callable(app), f"{transport} app must be an ASGI callable"
+
+
+def test_run_network_uses_the_compat_builder() -> None:
+    """Guard the regression at its source: `_run_network` must not go back to
+    poking `mcp.settings.host` directly, which only works on 1.x."""
+    import inspect
+
+    from yantrikdb_mcp import _run_network
+
+    src = inspect.getsource(_run_network)
+    assert "build_network_app" in src, (
+        "_run_network must build its ASGI app through _compat.build_network_app"
+    )
+    for forbidden in ("settings.host", "settings.port", "settings.transport_security"):
+        assert forbidden not in src, (
+            f"_run_network touches `{forbidden}` directly — that is 1.x-only "
+            f"state and raises ValueError on mcp 2.x. Route it through "
+            f"_compat.build_network_app instead."
+        )
+
+
+def test_transport_security_is_permissive_by_design() -> None:
+    """This server is reached over LAN/tunnel and gated by bearer-token auth,
+    not host/origin allowlists. Pin that intent so a future refactor doesn't
+    silently start rejecting the deployed clients."""
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    fields = set(TransportSecuritySettings.model_fields)
+    # Identical on both majors — only where you attach it changed.
+    assert {"allowed_hosts", "allowed_origins",
+            "enable_dns_rebinding_protection"} <= fields
+
+
+@pytest.mark.skipif(MCP_MAJOR != 2, reason="2.x-only shape check")
+def test_2x_settings_really_lacks_host() -> None:
+    """Documents WHY the shim exists: assigning host on 2.x is an error, not
+    a no-op. If a future 2.x restores the field this test fails loudly and the
+    shim can be simplified — a deliberate tripwire, not a bug."""
+    from yantrikdb_mcp.server import mcp
+
+    with pytest.raises((ValueError, AttributeError)):
+        mcp.settings.host = "0.0.0.0"


### PR DESCRIPTION
**v0.12.0 regression.** It shipped dual 1.x/2.x support with a 12-leg CI matrix — and still broke every **network** deployment on 2.x, because every e2e case drives **stdio**. The network path was never executed on either line.

## The defect

| | how host/security are configured |
|---|---|
| **1.x** | mutate state: `mcp.settings.host = ...`, `mcp.settings.transport_security.* = ...` |
| **2.x** | `Settings` has **no such fields** — they're arguments: `mcp.sse_app(host=..., transport_security=...)` |

On 2.x the old code doesn't misconfigure, it **raises**:

```
ValueError: "Settings" object has no field "host"
```

The process dies before uvicorn ever binds. Invisible to a stdio suite; fatal to real deployments, which run SSE behind bearer auth.

Found while preparing to upgrade a live SSE deployment to v0.12.0 — that box runs the one transport my tests never touched. Checking first beat discovering it by taking the server down.

## Fix

- **`_compat.build_network_app()`** owns the divergence and is the only place that knows how each major is configured. `TransportSecuritySettings` is identical across majors — only *where you attach it* moved.
- `_run_network()` delegates to it.
- **`tests/test_network_transport_compat.py`** builds the ASGI app exactly as `_run_network` does, for both transports, on whichever line is installed — so both CI legs cover it. Includes a source-level guard that `_run_network` can't regress to poking `settings.host`, and a 2.x tripwire asserting the field really is absent (if a future 2.x restores it, that test fails loudly and the shim can be simplified).

## Verification beyond unit tests

A **real SSE server** started on mcp 2.x with `YANTRIKDB_API_KEY` set: uvicorn bound, `/sse` returned **401** without a token and **200** with one.

Tests: **218 passed on mcp 1.x, 219 on mcp 2.x.**

## Lesson

A compatibility matrix only covers the code paths its tests actually execute. Twelve green legs proved stdio twice — not stdio *and* network. **Count paths, not legs.**