### PR TITLE
v0.13.0: engine 0.12 alignment — time-travel recall

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.12.1"
+version = "0.13.0"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"
@@ -66,7 +66,14 @@ dependencies = [
     # The PIN IS A BACKSTOP — the behavioral gates are the feature-probed
     # contract suites (test_v010_/test_v011_engine_contract_cases.py) +
     # tests/test_mcp_semantic_contract.py.
-    "yantrikdb>=0.10.0,<0.12.0",
+    # v0.12.0 (cross-validated): time-travel recall — recall_as_of(as_of, ...)
+    # returns the substrate as it was known at a past instant, and seal_pack
+    # gains recommended_top_k / recommended_min_similarity so a publisher can
+    # sign retrieval settings into a pack manifest. Purely ADDITIVE over 0.11:
+    # the full v0.10 + v0.11 gates stay green on 0.12.0 (verified BEFORE
+    # widening). Range widens to <0.13.0 only because 0.12 is now feature-probed
+    # by tests/test_v012_engine_contract_cases.py.
+    "yantrikdb>=0.10.0,<0.13.0",
     # D3 firewall, same rule as the engine pin above — and for the same
     # reason, learned the same way. `mcp[cli]>=1.2.0` was UNBOUNDED, so the
     # day the SDK shipped 2.0.0 it removed `mcp.server.fastmcp` and every

--- a/src/yantrikdb_mcp/http_backend.py
+++ b/src/yantrikdb_mcp/http_backend.py
@@ -554,6 +554,37 @@ class HttpBackend:
                                   hint="Trigger-upcoming listing isn't "
                                        "exposed over HTTP yet.")
 
+    # ── v0.12 engine surface — time-travel recall ───────────────────
+
+    def recall_as_of(self, as_of, query=None, query_embedding=None,
+                     top_k: int = 10, namespace=None, memory_type=None, **_kw):
+        """REFUSED over HTTP until the cluster advertises the capability.
+
+        This is deliberately NOT forwarded as an extra param on /v1/recall.
+        `as_of` changes WHICH QUESTION is being answered: a server that does
+        not implement it would ignore the field and return TODAY's memories,
+        so an agent asking "what did we know on 2026-08-01" would receive
+        present-day belief presented as historical fact — a confident wrong
+        answer, which is strictly worse than an error.
+
+        That is the same call made for `idempotency_key` on this backend
+        (agreement #6: never silently degrade). Contrast `include_superseded`,
+        which IS forwarded: an older server ignoring it returns the same row
+        shape, merely without the archaeology — a mild, self-evident
+        degradation rather than a changed question.
+
+        Flip this to a real /v1/recall?as_of=... call once the server
+        advertises it (e.g. via a capability flag on /v1/health), exactly as
+        planned for the idempotency-key forward.
+        """
+        raise self._not_supported(
+            "recall_as_of",
+            "time-travel recall is embedded-mode only for now. Forwarding it "
+            "blind would let a server that ignores `as_of` answer with today's "
+            "memories as though they were the past. Use embedded mode "
+            "(unset YANTRIKDB_SERVER_URL) for as_of queries.",
+        )
+
     # ── v0.8.0 / v0.9.0 engine surface — stubs until /v1/* lands ────
     # The engine v0.8.0/v0.9.0 added 25 new methods (tiering, demand,
     # conversation, tasks, hygiene primitives, link primitives,

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -1389,27 +1389,22 @@ def temporal(
     as_of: str | None = None,
     ctx: Context = None,
 ) -> str:
-    """Find stale or upcoming memories, or recall the past AS IT WAS KNOWN.
+    """Find stale or upcoming memories, or recall the past as it was known.
 
     ACTIONS:
-    - "stale": Important memories not accessed recently. Good for maintenance.
-    - "upcoming": Memories with approaching deadlines/events. Good for proactive alerts.
-    - "as_of": TIME-TRAVEL recall — what the substrate knew at a past moment.
-               Requires `query` and `as_of`. Memories recorded AFTER that
-               instant are excluded, so you see the belief you actually held
-               then, not today's. Use it to answer "what did we think before
-               X changed?" or to check whether a decision was made on
-               information available at the time. Needs engine v0.12+.
+    - "stale": Important memories not accessed recently.
+    - "upcoming": Memories with approaching deadlines/events.
+    - "as_of": Time-travel recall — excludes anything recorded after `as_of`,
+               so you see the belief held then, not today's. Engine v0.12+.
 
     Args:
         action: "stale", "upcoming", or "as_of".
         days: Inactivity threshold (stale) or look-ahead window (upcoming).
         limit: Max results.
         namespace: Optional filter.
-        query: Search text — REQUIRED for "as_of".
-        as_of: The past instant, REQUIRED for "as_of". Accepts "YYYY-MM-DD",
-               an ISO datetime ("2026-08-01T14:30:00Z"), a relative age
-               ("7d", "24h", "30m" = that long ago), or a unix timestamp.
+        query: Search text (required for "as_of").
+        as_of: Past instant (required for "as_of"): "2026-08-01",
+               "2026-08-01T14:30:00Z", "7d"/"24h" (ago), or unix seconds.
     """
     if action not in ("stale", "upcoming", "as_of"):
         raise ToolError("action must be 'stale', 'upcoming', or 'as_of'")

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import re
 import time
 
 from ._compat import Context, ToolAnnotations, ToolError
@@ -88,6 +89,64 @@ def _translate_idempotency_error(e: Exception, key: str) -> str | None:
             idempotency_key=key,
         )
     return None
+
+
+def _parse_as_of(value: str | float | int) -> float:
+    """Turn an agent-supplied instant into the unix float the engine requires.
+
+    `db.recall_as_of()` takes a unix timestamp and NOTHING else — an ISO string
+    raises a bare `TypeError: argument 'as_of': must be real number, not str`.
+    An agent asked for "what did we know on 2026-08-01" will reach for the
+    date string every time, so the MCP layer absorbs that instead of forwarding
+    a type error the model cannot act on.
+
+    Accepted, in the order an agent is likely to try them:
+      "2026-08-01"              date (UTC midnight)
+      "2026-08-01T14:30:00Z"    ISO datetime, Z or +00:00 or naive (assumed UTC)
+      "7d" / "24h" / "30m"      relative — that long BEFORE now
+      1785898500 / "1785898500" unix seconds
+
+    Raises ToolError naming every accepted form — a parse failure must teach
+    the caller the grammar, not just report a rejection.
+    """
+    from datetime import datetime, timezone
+
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+
+    s = str(value).strip()
+    if not s:
+        raise ToolError("as_of is empty — give a date, ISO datetime, relative age, or unix timestamp")
+
+    # Relative: "7d" / "24h" / "30m" / "90s" = that long ago.
+    m = re.fullmatch(r"(\d+(?:\.\d+)?)\s*([smhdw])", s, re.IGNORECASE)
+    if m:
+        n = float(m.group(1))
+        mult = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}[m.group(2).lower()]
+        return time.time() - (n * mult)
+
+    # Bare unix timestamp (as a string).
+    try:
+        return float(s)
+    except ValueError:
+        pass
+
+    # ISO date / datetime. Normalise the trailing Z that fromisoformat rejects
+    # on older Pythons, and treat a naive timestamp as UTC rather than local —
+    # server-local time would make the same query mean different things on
+    # different hosts.
+    iso = s[:-1] + "+00:00" if s.endswith(("Z", "z")) else s
+    try:
+        dt = datetime.fromisoformat(iso)
+    except ValueError:
+        raise ToolError(
+            f"could not parse as_of={value!r}. Use a date (2026-08-01), an ISO "
+            f"datetime (2026-08-01T14:30:00Z), a relative age (7d / 24h / 30m), "
+            f"or a unix timestamp."
+        )
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
 
 
 # ── v0.10.0 response-shaping helpers ──
@@ -1326,24 +1385,70 @@ def temporal(
     days: float = 30.0,
     limit: int = 20,
     namespace: str | None = None,
+    query: str | None = None,
+    as_of: str | None = None,
     ctx: Context = None,
 ) -> str:
-    """Find stale or upcoming memories based on time.
+    """Find stale or upcoming memories, or recall the past AS IT WAS KNOWN.
 
     ACTIONS:
     - "stale": Important memories not accessed recently. Good for maintenance.
     - "upcoming": Memories with approaching deadlines/events. Good for proactive alerts.
+    - "as_of": TIME-TRAVEL recall — what the substrate knew at a past moment.
+               Requires `query` and `as_of`. Memories recorded AFTER that
+               instant are excluded, so you see the belief you actually held
+               then, not today's. Use it to answer "what did we think before
+               X changed?" or to check whether a decision was made on
+               information available at the time. Needs engine v0.12+.
 
     Args:
-        action: "stale" or "upcoming".
+        action: "stale", "upcoming", or "as_of".
         days: Inactivity threshold (stale) or look-ahead window (upcoming).
         limit: Max results.
         namespace: Optional filter.
+        query: Search text — REQUIRED for "as_of".
+        as_of: The past instant, REQUIRED for "as_of". Accepts "YYYY-MM-DD",
+               an ISO datetime ("2026-08-01T14:30:00Z"), a relative age
+               ("7d", "24h", "30m" = that long ago), or a unix timestamp.
     """
-    if action not in ("stale", "upcoming"):
-        raise ToolError("action must be 'stale' or 'upcoming'")
+    if action not in ("stale", "upcoming", "as_of"):
+        raise ToolError("action must be 'stale', 'upcoming', or 'as_of'")
 
     db = _get_db(ctx)
+
+    if action == "as_of":
+        if not query or not query.strip():
+            raise ToolError("as_of requires `query` — the text to search for at that point in time")
+        if not as_of:
+            raise ToolError(
+                "as_of requires `as_of` — the past instant to look back to "
+                '(e.g. "2026-08-01", "2026-08-01T14:30:00Z", "7d", or a unix timestamp)'
+            )
+        if not hasattr(db, "recall_as_of"):
+            # Honest surface (agreement #6): name the requirement, don't
+            # silently fall back to a present-day recall that would answer a
+            # DIFFERENT question than the one asked.
+            return _err(
+                "time-travel recall needs engine v0.12+; this server runs an older "
+                "engine. Upgrade the engine, or use recall() for present-day results "
+                "(note: that answers a different question).",
+                required_engine="0.12.0",
+            )
+        ts = _parse_as_of(as_of)
+        rows = db.recall_as_of(ts, query=query, top_k=limit, namespace=namespace)
+        return json.dumps({
+            "as_of": as_of,
+            "as_of_unix": round(ts, 3),
+            "count": len(rows or []),
+            # Stated explicitly so the agent doesn't read an empty/short result
+            # as "nothing was ever known about this".
+            "note": "only memories recorded at or before as_of are included",
+            "results": [
+                {"rid": m.get("rid"), "text": m.get("text"),
+                 "importance": m.get("importance"), "created_at": m.get("created_at")}
+                for m in (rows or []) if isinstance(m, dict)
+            ],
+        })
 
     if action == "stale":
         memories = db.stale(days, limit, namespace)

--- a/tests/test_temporal_as_of.py
+++ b/tests/test_temporal_as_of.py
@@ -1,0 +1,120 @@
+"""`temporal(action="as_of", ...)` — the MCP surface for time-travel recall.
+
+The engine's `recall_as_of` takes a unix float and NOTHING else; an ISO string
+raises a bare `TypeError: argument 'as_of': must be real number, not str`. An
+agent asked "what did we know on 2026-08-01" will reach for the date string
+every single time, so this layer parses the forms an agent actually produces
+and, on failure, returns an error that TEACHES the grammar instead of leaking
+a type error the model cannot act on.
+"""
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+from yantrikdb_mcp._compat import ToolError
+from yantrikdb_mcp.tools import _parse_as_of, temporal
+
+
+# ── the parser ───────────────────────────────────────────────────────
+
+
+def test_parses_iso_date_as_utc_midnight():
+    ts = _parse_as_of("2026-08-01")
+    assert datetime.fromtimestamp(ts, timezone.utc).strftime("%Y-%m-%d") == "2026-08-01"
+
+
+@pytest.mark.parametrize("s", ["2026-08-01T14:30:00Z", "2026-08-01T14:30:00+00:00",
+                               "2026-08-01T14:30:00"])
+def test_parses_iso_datetimes_including_bare_Z(s):
+    """`fromisoformat` rejects a trailing Z on older Pythons, and a NAIVE
+    stamp must be read as UTC — server-local time would make the same query
+    mean different things on different hosts."""
+    dt = datetime.fromtimestamp(_parse_as_of(s), timezone.utc)
+    assert (dt.year, dt.month, dt.day, dt.hour) == (2026, 8, 1, 14)
+
+
+@pytest.mark.parametrize("rel,secs", [("7d", 604800), ("24h", 86400),
+                                      ("30m", 1800), ("90s", 90)])
+def test_relative_ages_look_backwards(rel, secs):
+    """"7d" means seven days AGO, not seven days from the epoch."""
+    assert abs((time.time() - secs) - _parse_as_of(rel)) < 5
+
+
+def test_accepts_unix_number_and_numeric_string():
+    assert _parse_as_of(1785898500) == 1785898500.0
+    assert _parse_as_of("1785898500") == 1785898500.0
+
+
+def test_unparseable_input_names_every_accepted_form():
+    """A rejection must teach the grammar — otherwise the agent's next attempt
+    is another guess."""
+    with pytest.raises(ToolError) as e:
+        _parse_as_of("last tuesday")
+    msg = str(e.value)
+    for hint in ("2026-08-01", "unix", "7d"):
+        assert hint in msg, f"error should mention {hint!r}; got: {msg}"
+
+
+# ── the tool surface ─────────────────────────────────────────────────
+
+
+class _Ctx:
+    """Minimal stand-in for the MCP request context."""
+
+    def __init__(self, db):
+        self.request_context = type("R", (), {"lifespan_context": {"lazy": type("L", (), {"db": db})()}})()
+
+
+@pytest.fixture
+def ctx(tmp_path):
+    import os
+
+    os.environ.setdefault("YANTRIKDB_EMBEDDER", "bundled")
+    from yantrikdb_mcp.embedder import load_engine
+
+    db = load_engine(str(tmp_path / "asof.db"), model_name="bundled")
+    yield _Ctx(db)
+    try:
+        db.close()
+    except AttributeError:
+        pass
+
+
+def test_as_of_requires_query_and_as_of(ctx):
+    with pytest.raises(ToolError, match="query"):
+        temporal(action="as_of", as_of="2026-08-01", ctx=ctx)
+    with pytest.raises(ToolError, match="as_of"):
+        temporal(action="as_of", query="anything", ctx=ctx)
+
+
+def test_rejects_unknown_action(ctx):
+    with pytest.raises(ToolError, match="as_of"):
+        temporal(action="sideways", ctx=ctx)
+
+
+@pytest.mark.skipif(
+    not hasattr(__import__("yantrikdb").YantrikDB, "recall_as_of"),
+    reason="engine lacks recall_as_of — pre-v0.12",
+)
+def test_as_of_end_to_end_excludes_later_writes(ctx):
+    db = ctx.request_context.lifespan_context["lazy"].db
+    db.record("Tool-level probe: port is 8420", namespace="tl")
+    time.sleep(1.1)
+    cut = time.time()
+    time.sleep(1.1)
+    db.record("Tool-level probe: port is 9000", namespace="tl")
+
+    out = json.loads(temporal(action="as_of", query="tool-level probe port",
+                              as_of=str(cut), namespace="tl", ctx=ctx))
+    blob = json.dumps(out["results"])
+    assert "8420" in blob and "9000" not in blob, (
+        "the tool must not surface memories recorded after as_of"
+    )
+    # The response states its own filtering so an empty/short result is not
+    # misread as "nothing was ever known".
+    assert "as_of" in out and "note" in out
+    assert out["count"] == len(out["results"])

--- a/tests/test_tool_profiles_and_budget.py
+++ b/tests/test_tool_profiles_and_budget.py
@@ -55,7 +55,25 @@ FULL_TOOLS = CORE_TOOLS | {
 # pack silently rewrites what the agent believes. The headroom above the
 # measured 43,289 is deliberately small so the NEXT addition also has to be
 # argued for. `core` profile is unaffected — pack is specialist-tier.
-SCHEMA_BUDGET_CHARS = 45_500
+#
+# 45_500 -> 46_800 on the v0.13.0 branch (REVIEWED, two reasons):
+#
+# (1) `temporal` gains `as_of` + `query` for engine v0.12 time-travel recall.
+#     The gate fired at 46,080 and the discretionary prose was trimmed first
+#     (temporal 1,846 -> 1,351); what remains is the irreducible cost of two
+#     params plus the accepted-timestamp grammar. That grammar EARNS its
+#     chars: the engine takes a unix float only, so an agent that guesses
+#     "2026-08-01" burns a whole call on a TypeError it cannot act on.
+#
+# (2) THIS GATE IS PYTHON-VERSION SENSITIVE, which the old number hid.
+#     Same commit, same tools: 43,813 on py3.13 but 46,080 on py3.10/3.12 —
+#     ~1,700 chars of difference in how the JSON schema for `str | None`
+#     unions is rendered. The budget must clear the LARGEST supported
+#     interpreter, not the one a developer happens to run, or CI fails on a
+#     diff that looked fine locally (exactly what happened here).
+#     Follow-up worth doing: measure per-interpreter rather than assuming one
+#     number fits all, so this ceiling stops drifting with the Python matrix.
+SCHEMA_BUDGET_CHARS = 46_800
 
 
 def _rpc(proc, method, params, mid):

--- a/tests/test_v012_engine_contract_cases.py
+++ b/tests/test_v012_engine_contract_cases.py
@@ -1,0 +1,115 @@
+"""v0.12 engine behavioral-contract cases — time-travel recall.
+
+Same GATING RULE as the v0.10/v0.11 suites: every case gates on a FEATURE
+PROBE (hasattr / signature), never a version parse. On a pre-v0.12 engine
+these SKIP naming the missing surface; on v0.12 they RUN and become the wall
+that lets pyproject widen the pin to <0.13.0.
+
+The v0.12 delta over 0.11.3 is small and purely additive:
+  1. recall_as_of(as_of, query=..., ...) — recall the past AS IT WAS KNOWN
+  2. seal_pack(..., recommended_top_k=, recommended_min_similarity=) — the
+     retrieval settings a publisher signs into a pack manifest
+
+Behaviours pinned here were learned by probing 0.12.0, not assumed — including
+the sharp edge that `as_of` accepts ONLY a real number, which is why the MCP
+layer parses agent-friendly forms before calling through.
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import tempfile
+import time
+
+import pytest
+
+from yantrikdb import YantrikDB
+
+
+def _param(method, name: str) -> bool:
+    try:
+        return name in inspect.signature(method).parameters
+    except (ValueError, TypeError):
+        return False
+
+
+HAS_AS_OF = hasattr(YantrikDB, "recall_as_of")
+HAS_PACK_RECOMMENDATIONS = _param(getattr(YantrikDB, "seal_pack", None), "recommended_top_k") \
+    if hasattr(YantrikDB, "seal_pack") else False
+
+
+@pytest.fixture(scope="module")
+def db():
+    os.environ.setdefault("YANTRIKDB_EMBEDDER", "bundled")
+    from yantrikdb_mcp.embedder import load_engine
+
+    d = load_engine(os.path.join(tempfile.mkdtemp(), "v012.db"), model_name="bundled")
+    yield d
+    try:
+        d.close()
+    except AttributeError:
+        pass
+
+
+# ── 1. time-travel recall ────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not HAS_AS_OF, reason="engine lacks recall_as_of — pre-v0.12 surface")
+def test_recall_as_of_excludes_later_writes(db):
+    """The core contract: a memory recorded AFTER the cutoff must not appear.
+    This is what makes the result 'the belief held then' rather than 'today's
+    belief filtered by date'."""
+    db.record("Time-travel probe: the limit is 100 rps", namespace="asof")
+    time.sleep(1.1)
+    cut = time.time()
+    time.sleep(1.1)
+    db.record("Time-travel probe: the limit is 500 rps", namespace="asof")
+
+    past = db.recall_as_of(cut, query="time-travel probe limit rps", namespace="asof", top_k=10)
+    now = db.recall_as_of(time.time(), query="time-travel probe limit rps", namespace="asof", top_k=10)
+
+    past_text = " ".join((r.get("text") or "") for r in (past or []) if isinstance(r, dict))
+    now_text = " ".join((r.get("text") or "") for r in (now or []) if isinstance(r, dict))
+
+    assert "100 rps" in past_text, "the value known at the cutoff must be returned"
+    assert "500 rps" not in past_text, (
+        "a memory recorded AFTER as_of leaked into the past view — time-travel "
+        "recall would then answer with knowledge the agent did not have"
+    )
+    assert "500 rps" in now_text, "as_of=now must include the later write"
+
+
+@pytest.mark.skipif(not HAS_AS_OF, reason="engine lacks recall_as_of — pre-v0.12 surface")
+def test_recall_as_of_requires_a_real_number(db):
+    """The sharp edge the MCP layer exists to absorb: an ISO string raises
+    TypeError. If this ever starts accepting strings, `_parse_as_of` can be
+    simplified — so pin it as a tripwire rather than leaving it folklore."""
+    with pytest.raises(TypeError):
+        db.recall_as_of("2026-08-01T00:00:00Z", query="anything", namespace="asof")
+
+
+# ── 2. pack retrieval recommendations ────────────────────────────────
+
+
+@pytest.mark.skipif(
+    not HAS_PACK_RECOMMENDATIONS,
+    reason="engine seal_pack lacks recommended_* — pre-v0.12 surface",
+)
+def test_seal_pack_carries_recommended_retrieval_settings(db):
+    """A publisher can sign retrieval hints INTO the manifest, so a consumer
+    doesn't have to guess top_k / similarity for someone else's corpus."""
+    db.record("Recommendation probe row", namespace="recns")
+    dest = os.path.join(tempfile.mkdtemp(), "rec.ypack")
+    ident = db.embedder_identity() or {}
+    db.seal_pack(
+        dest, "rec-pack", "1.0.0", "rec-origin", namespace="recns",
+        embedder_name=ident.get("name"), embedder_digest=ident.get("digest"),
+        embedder_dim=ident.get("dim"),
+        recommended_top_k=7, recommended_min_similarity=0.42,
+    )
+    man = db.read_pack_manifest(dest)
+    blob = str(man)
+    assert "7" in blob and "0.42" in blob, (
+        f"manifest must carry the recommended retrieval settings; got keys "
+        f"{sorted(man.keys())}"
+    )


### PR DESCRIPTION
Engine **0.12.0**'s delta over 0.11.3 is small and purely additive:

- **`recall_as_of(as_of, query=...)`** — recall the substrate *as it was known* at a past instant
- **`seal_pack(..., recommended_top_k=, recommended_min_similarity=)`** — retrieval settings a publisher signs into a pack manifest

The full v0.10 + v0.11 gates were verified green on 0.12.0 **before** the pin widened to `<0.13.0`. The pin is a backstop; the feature-probed contract suites are the gate.

## New: `temporal(action="as_of", query=..., as_of=...)`

Time-travel recall as a consumer surface. Memories recorded *after* the instant are excluded, so the agent sees the belief actually held then — useful for *"what did we think before X changed?"* and for checking whether a decision was made on information available at the time.

Placed on **`temporal`** (the time-oriented specialist) rather than on `recall`: `recall` is the hottest tool in the set, and every parameter added there costs schema tokens on calls that will never use it.

### `_parse_as_of()` — absorbing a sharp edge

The engine takes a unix float and **nothing else**; an ISO string raises a bare `TypeError: argument 'as_of': must be real number, not str`. An agent asked *"what did we know on 2026-08-01"* will reach for the date string every time — so this layer accepts what agents actually produce:

| input | meaning |
|---|---|
| `2026-08-01` | date, UTC midnight |
| `2026-08-01T14:30:00Z` | ISO datetime (bare `Z`, `+00:00`, or naive) |
| `7d` / `24h` / `30m` | that long **ago** |
| `1785898500` | unix seconds |

On failure it returns an error that **teaches the grammar** rather than leaking a type error the model can't act on. Naive datetimes are read as **UTC** — server-local time would make the same query mean different things on different hosts.

The response also states its own filtering (`"only memories recorded at or before as_of are included"`) so a short result isn't misread as *"nothing was ever known about this"*.

## `HttpBackend` refuses `recall_as_of` rather than forwarding it

`as_of` changes **which question is being answered**. A server that ignored the field would return today's memories, and the agent would receive present-day belief as historical fact — a **confident wrong answer, strictly worse than an error**. Same call as `idempotency_key` (agreement #6).

Contrast `include_superseded`, which *is* forwarded: an older server ignoring it returns the same row shape, merely without the archaeology — a mild, self-evident degradation rather than a changed question.

Caught by `test_backend_parity` — the gate working as designed.

## Tests — 234 passed, 4 skipped, 1 xfailed

- **`test_v012_engine_contract_cases.py`** — feature-probed `as_of` exclusion, signed pack recommendations, plus a **tripwire** pinning that the engine really does reject ISO strings (if that ever changes, `_parse_as_of` can be simplified).
- **`test_temporal_as_of.py`** — every accepted timestamp form, UTC handling for naive stamps, `"7d"` meaning *ago*, the grammar-teaching rejection, and an end-to-end check that later writes stay excluded.

Wire-verified over stdio JSON-RPC: `as_of` returned only the pre-cutoff memory, and a malformed value produced the teaching error.