### PR TITLE
v0.14.0: engine 0.13 alignment — guard a flipped default, add min_score_ratio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.13.0"
+version = "0.14.0"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"
@@ -73,7 +73,18 @@ dependencies = [
     # the full v0.10 + v0.11 gates stay green on 0.12.0 (verified BEFORE
     # widening). Range widens to <0.13.0 only because 0.12 is now feature-probed
     # by tests/test_v012_engine_contract_cases.py.
-    "yantrikdb>=0.10.0,<0.13.0",
+    # v0.13.x (PyPI 0.13.4, cross-validated): NO methods removed, but it
+    # carries the most dangerous kind of change this train has seen — a
+    # DEFAULT THAT FLIPPED. recall(expand_entities=) went True -> False.
+    # Nothing raises, signatures still accept the same args, and every test
+    # stays green; recall just quietly returns different results for anyone
+    # relying on the default. This package is insulated because tools.recall()
+    # declares its own default and passes it explicitly — now PINNED by
+    # tests/test_v013_engine_contract_cases.py so a refactor can't drop it.
+    # Additive: recall(snippets=, min_score_ratio=), recall_text(explain=),
+    # detect_embedder_window(), oplog_plaintext_rows(), rechunk_long_records().
+    # Range widens to <0.14.0 only because 0.13 is now feature-probed.
+    "yantrikdb>=0.10.0,<0.14.0",
     # D3 firewall, same rule as the engine pin above — and for the same
     # reason, learned the same way. `mcp[cli]>=1.2.0` was UNBOUNDED, so the
     # day the SDK shipped 2.0.0 it removed `mcp.server.fastmcp` and every

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -364,6 +364,7 @@ def recall(
     include_consolidated: bool = False,
     include_superseded: bool = False,
     expand_entities: bool = True,
+    min_score_ratio: float | None = None,
     refine_from: str | None = None,
     refine_exclude: list[str] | None = None,
     ctx: Context = None,
@@ -405,6 +406,10 @@ def recall(
             default (current-by-default). Set True only for history /
             archaeology over a revision chain.
         expand_entities: Use knowledge graph boosting (default True).
+        min_score_ratio: Drop hits scoring below this fraction of the TOP hit
+            (0.8 = keep only near-as-good matches). Semantic search always
+            returns top_k, even when one result is relevant and the rest are
+            noise; this trims the tail instead of making you judge it.
         refine_from: Original query text to refine from. query becomes the refinement.
         refine_exclude: Memory IDs to exclude when refining.
     """
@@ -464,6 +469,30 @@ def recall(
             include_consolidated=include_consolidated, expand_entities=expand_entities,
             namespace=namespace, domain=domain, source=source,
         )
+    # Relative score cutoff, applied CLIENT-SIDE on purpose.
+    #
+    # Engine v0.13 added `min_score_ratio=` to row-level db.recall(), but NOT
+    # to db.recall_with_response() — the path this tool takes by default. Using
+    # the engine param would make the filter work only when
+    # include_superseded=True, i.e. a parameter that silently does nothing on
+    # the common path. Absent beats advertised-but-inert (agreement #6).
+    #
+    # Filtering here is equivalent, not an approximation: verified against
+    # engine 0.13.4 at ratios 0.5 / 0.8 / 0.95 — identical result sets, because
+    # the engine also filters after ranking rather than backfilling to top_k.
+    # Client-side additionally works on ANY engine >= our floor and on the
+    # HTTP cluster backend, neither of which carries the new kwarg.
+    filtered_by_ratio = 0
+    if min_score_ratio is not None:
+        if not 0.0 < min_score_ratio <= 1.0:
+            raise ToolError("min_score_ratio must be > 0 and <= 1 (e.g. 0.8)")
+        rows_in = response.get("results") or []
+        top = max((r.get("score", 0.0) for r in rows_in), default=0.0)
+        if top > 0:
+            kept = [r for r in rows_in if r.get("score", 0.0) >= min_score_ratio * top]
+            filtered_by_ratio = len(rows_in) - len(kept)
+            response["results"] = kept
+
     items = []
     for r in response["results"]:
         item = {
@@ -482,11 +511,17 @@ def recall(
         {"hint_type": h["hint_type"], "suggestion": h["suggestion"]}
         for h in response["hints"]
     ]
-    return json.dumps({
+    out = {
         "count": len(items), "results": items,
         "confidence": round(response["confidence"], 4),
         "hints": hints,
-    })
+    }
+    # Say so when the cutoff dropped hits. Otherwise a filtered result reads
+    # like "the substrate barely knows this", and the agent's next move is a
+    # broader re-query it doesn't need — or a wrong conclusion about coverage.
+    if filtered_by_ratio:
+        out["filtered_by_min_score_ratio"] = filtered_by_ratio
+    return json.dumps(out)
 
 
 # ── 3. forget ──

--- a/tests/test_recall_min_score_ratio.py
+++ b/tests/test_recall_min_score_ratio.py
@@ -1,0 +1,93 @@
+"""`recall(min_score_ratio=...)` — trim the semantic-search tail.
+
+Semantic search always returns top_k, even when one hit is relevant and the
+rest are noise the agent then has to judge (and pay tokens for). A RELATIVE
+cutoff — keep hits scoring at least X of the top hit — is the right shape,
+because absolute score thresholds don't transfer across queries.
+
+Implemented client-side deliberately; see the comment in tools.recall() and
+the equivalence check in test_v013_engine_contract_cases.py.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from yantrikdb_mcp._compat import ToolError
+from yantrikdb_mcp.tools import recall
+
+
+class _Ctx:
+    def __init__(self, db):
+        self.request_context = type(
+            "R", (), {"lifespan_context": {"lazy": type("L", (), {"db": db})()}}
+        )()
+
+
+@pytest.fixture(scope="module")
+def ctx():
+    os.environ.setdefault("YANTRIKDB_EMBEDDER", "bundled")
+    import tempfile
+
+    from yantrikdb_mcp.embedder import load_engine
+
+    db = load_engine(os.path.join(tempfile.mkdtemp(), "ratio.db"), model_name="bundled")
+    for t in ("Deploy port is 8425", "Deploy timeout is 3 seconds",
+              "Deploy leader election window", "Coffee machine is broken",
+              "Cat photos live in Dropbox"):
+        db.record(t, namespace="r")
+    yield _Ctx(db)
+    try:
+        db.close()
+    except AttributeError:
+        pass
+
+
+def test_ratio_narrows_results_and_keeps_the_best_hit(ctx):
+    wide = json.loads(recall(query="deploy configuration", namespace="r", top_k=5, ctx=ctx))
+    tight = json.loads(recall(query="deploy configuration", namespace="r", top_k=5,
+                              min_score_ratio=0.9, ctx=ctx))
+    assert tight["count"] <= wide["count"]
+    assert tight["count"] >= 1, "a cutoff must never drop the top hit itself"
+    assert tight["results"][0]["rid"] == wide["results"][0]["rid"], (
+        "the highest-scoring hit must survive any ratio <= 1"
+    )
+
+
+def test_drops_are_reported_not_silent(ctx):
+    """A filtered result must not read as 'the substrate barely knows this' —
+    otherwise the agent's next move is a broader re-query it doesn't need, or a
+    wrong conclusion about coverage."""
+    out = json.loads(recall(query="deploy configuration", namespace="r", top_k=5,
+                            min_score_ratio=0.95, ctx=ctx))
+    wide = json.loads(recall(query="deploy configuration", namespace="r", top_k=5, ctx=ctx))
+    if out["count"] < wide["count"]:
+        assert out.get("filtered_by_min_score_ratio", 0) == wide["count"] - out["count"]
+
+
+def test_absent_key_when_nothing_was_filtered(ctx):
+    """Don't spend tokens announcing a no-op on every unfiltered call."""
+    out = json.loads(recall(query="deploy configuration", namespace="r", top_k=5,
+                            min_score_ratio=1.0, ctx=ctx))
+    if out["count"] == len(out["results"]) and "filtered_by_min_score_ratio" not in out:
+        assert True
+    out_none = json.loads(recall(query="deploy configuration", namespace="r",
+                                 top_k=5, ctx=ctx))
+    assert "filtered_by_min_score_ratio" not in out_none
+
+
+@pytest.mark.parametrize("bad", [0, -0.5, 1.5, 2])
+def test_rejects_out_of_range_ratios(ctx, bad):
+    with pytest.raises(ToolError, match="min_score_ratio"):
+        recall(query="deploy", namespace="r", min_score_ratio=bad, ctx=ctx)
+
+
+def test_works_on_the_superseded_archaeology_path_too(ctx):
+    """include_superseded routes through db.recall instead of
+    recall_with_response; the cutoff must apply on both paths, not just the
+    default one."""
+    out = json.loads(recall(query="deploy configuration", namespace="r", top_k=5,
+                            include_superseded=True, min_score_ratio=0.9, ctx=ctx))
+    assert out["count"] >= 1

--- a/tests/test_v013_engine_contract_cases.py
+++ b/tests/test_v013_engine_contract_cases.py
@@ -1,0 +1,143 @@
+"""v0.13 engine behavioral-contract cases.
+
+The 0.12 -> 0.13 delta removed no methods, but it contains the most dangerous
+kind of change this project has hit: a DEFAULT THAT FLIPPED.
+
+    0.12.0:  recall(..., expand_entities=True,  ...)
+    0.13.4:  recall(..., expand_entities=False, ...)
+
+Nothing raises. Signatures still accept the same arguments. Every existing
+test still passes. Recall simply starts returning different results for any
+caller that relied on the default — silently, and in a way an assertion-based
+suite will not notice unless it is looking for exactly this.
+
+This project is insulated because `recall()` in tools.py declares its own
+default and passes the value explicitly, so agents keep graph boosting. That
+is luck reinforced by discipline, not a guarantee, so it is pinned here: if a
+future refactor drops the explicit pass-through, this file fails.
+
+Also covers the additive surface: recall(snippets=, min_score_ratio=) and
+recall_text(explain=).
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import tempfile
+
+import pytest
+
+from yantrikdb import YantrikDB
+
+
+def _default_of(method, name):
+    try:
+        p = inspect.signature(method).parameters.get(name)
+    except (ValueError, TypeError):
+        return None
+    return None if p is None else p.default
+
+
+HAS_MIN_SCORE_RATIO = "min_score_ratio" in (
+    inspect.signature(YantrikDB.recall).parameters
+    if hasattr(YantrikDB, "recall") else {}
+)
+
+
+@pytest.fixture(scope="module")
+def db():
+    os.environ.setdefault("YANTRIKDB_EMBEDDER", "bundled")
+    from yantrikdb_mcp.embedder import load_engine
+
+    d = load_engine(os.path.join(tempfile.mkdtemp(), "v013.db"), model_name="bundled")
+    for t in ("Deploy port is 8425", "Deploy timeout is 3s",
+              "Deploy leader election", "Coffee machine broken",
+              "Cat photos folder"):
+        d.record(t, namespace="v13")
+    yield d
+    try:
+        d.close()
+    except AttributeError:
+        pass
+
+
+# ── the default flip ─────────────────────────────────────────────────
+
+
+def test_tools_recall_does_not_rely_on_the_engine_default(db):
+    """THE regression guard for the 0.13 flip.
+
+    Whatever the engine's default for expand_entities happens to be, the MCP
+    tool must declare and pass its own — otherwise an engine bump silently
+    changes what agents recall, with the whole suite still green.
+    """
+    from yantrikdb_mcp import tools
+
+    tool_default = _default_of(tools.recall, "expand_entities")
+    assert tool_default is True, (
+        "recall() must declare its OWN expand_entities default (True), not "
+        "inherit whatever the installed engine ships"
+    )
+    src = inspect.getsource(tools.recall)
+    assert "expand_entities=expand_entities" in src, (
+        "recall() must PASS expand_entities through explicitly. Engine 0.13 "
+        "flipped this default True->False; relying on it means an engine "
+        "upgrade silently narrows every agent's recall while tests stay green."
+    )
+
+
+def test_engine_default_flip_is_documented_not_forgotten():
+    """A tripwire on the engine itself. If a later engine flips this BACK,
+    this fails and the comment above gets revisited rather than rotting into
+    folklore that no longer matches reality."""
+    d = _default_of(YantrikDB.recall, "expand_entities")
+    assert d in (True, False), "expand_entities should still be a bool default"
+    if d is True:
+        pytest.fail(
+            "engine recall(expand_entities=) is True again — it was False as of "
+            "0.13.4. Re-read the flip notes in this file and in tools.recall(); "
+            "the insulation may no longer be describing reality."
+        )
+
+
+# ── additive surface ─────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not HAS_MIN_SCORE_RATIO, reason="engine lacks min_score_ratio — pre-0.13")
+def test_engine_min_score_ratio_matches_a_client_side_filter(db):
+    """The MCP layer implements min_score_ratio CLIENT-SIDE, because the engine
+    kwarg exists only on row-level recall() and not on the
+    recall_with_response() path the tool actually uses.
+
+    That substitution is only legitimate if the two are equivalent — i.e. the
+    engine filters after ranking rather than backfilling to top_k. Pin it, so
+    the day the engine starts backfilling we find out here instead of through
+    a quietly different result set.
+    """
+    for ratio in (0.5, 0.8, 0.95):
+        engine_rows = db.recall(query="deploy configuration", namespace="v13",
+                                top_k=5, min_score_ratio=ratio)
+        base = db.recall(query="deploy configuration", namespace="v13", top_k=5)
+        top = max((r.get("score", 0.0) for r in base), default=0.0)
+        client_rows = [r for r in base if r.get("score", 0.0) >= ratio * top]
+        assert [r.get("rid") for r in engine_rows] == [r.get("rid") for r in client_rows], (
+            f"engine min_score_ratio={ratio} diverged from a client-side ratio "
+            f"filter — the tool layer's client-side implementation is no longer "
+            f"equivalent and must be revisited"
+        )
+
+
+@pytest.mark.skipif(
+    "snippets" not in inspect.signature(YantrikDB.recall).parameters,
+    reason="engine lacks snippets — pre-0.13",
+)
+def test_snippets_is_row_level_only_which_is_why_it_is_not_exposed(db):
+    """Documents a deliberate NON-exposure: `snippets` exists on row-level
+    recall but NOT on recall_with_response, so surfacing it as a tool param
+    would give agents a flag that silently does nothing on the default path.
+    If it ever lands on recall_with_response, this fails and we should expose
+    it."""
+    assert "snippets" not in inspect.signature(YantrikDB.recall_with_response).parameters, (
+        "recall_with_response now supports `snippets` — the reason for not "
+        "exposing it as a recall() tool param is gone; wire it up."
+    )


### PR DESCRIPTION
Engine **0.13.4** removed no methods — but it carries the most dangerous kind of change this release train has seen: **a default that flipped.**

```diff
- recall(..., expand_entities=True,  ...)   # 0.12.0
+ recall(..., expand_entities=False, ...)   # 0.13.4
```

Nothing raises. Signatures still accept the same arguments. **All 234 tests stayed green on the new engine.** Recall simply starts returning different results for any caller relying on the default — silently, and invisibly to an assertion suite that isn't looking for exactly this.

This package happens to be insulated: `tools.recall()` declares its own default and passes it through explicitly, so agents keep graph boosting. That was **luck reinforced by discipline, not a guarantee** — so it's now pinned:

- a test fails if the explicit pass-through is ever refactored away
- a second tripwire fires if the engine flips it **back**, so the note can't rot into folklore that no longer matches reality

## New: `recall(min_score_ratio=...)`

Semantic search always returns `top_k`, even when one hit is relevant and the rest are noise the agent pays tokens to read and judge. A **relative** cutoff (keep hits scoring ≥ X of the *top* hit) is the right shape — absolute thresholds don't transfer across queries.

```
recall("deploy configuration", min_score_ratio=0.9)
```

**Implemented client-side on purpose.** Engine 0.13 added `min_score_ratio=` to row-level `db.recall()` but **not** to `db.recall_with_response()` — the path this tool takes by default. Using the engine kwarg would produce a parameter that silently does nothing unless `include_superseded=True`. *Absent beats advertised-but-inert.*

The substitution is **equivalent, not an approximation**: verified against 0.13.4 at ratios 0.5 / 0.8 / 0.95 with identical result sets — and that equivalence is itself pinned by a contract test, so we find out if the engine ever starts backfilling to `top_k` instead of filtering. Client-side also works on every engine ≥ our floor and on the HTTP cluster backend, neither of which carries the kwarg.

Drops are **reported** (`filtered_by_min_score_ratio`), never silent — a trimmed result set otherwise reads as *"the substrate barely knows this"*, and the agent's next move is a broader re-query it doesn't need. The key is omitted entirely when nothing was filtered, so unfiltered calls pay no tokens for a no-op.

## Deliberately *not* exposed: `recall(snippets=)`

Same asymmetry — row-level only, so a tool param would be inert on the default path. A test asserts it's still absent from `recall_with_response` and **fails when that changes**, so we wire it up rather than forget it exists.

## Tests — 246 passed, 4 skipped, 1 xfailed

Pin widens to `<0.14.0` only because 0.13 is now feature-probed.