### PR TITLE
reach the Prime Agent segment: verified kernel skill + guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 **YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server.**
 
-Works with Claude Code, Cursor, Windsurf, [Hermes Agent](docs/hermes.md), and any MCP-compatible client. Ships a portable [Agent Skills](https://agentskills.io) skill — [`skills/persistent-memory`](skills/persistent-memory/SKILL.md) — that teaches any compliant harness the memory golden path.
+Works with Claude Code, Cursor, Windsurf, [Hermes Agent](docs/hermes.md), [Prime Agent](docs/prime-agent.md), and any MCP-compatible client. Ships a portable [Agent Skills](https://agentskills.io) skill — [`skills/persistent-memory`](skills/persistent-memory/SKILL.md) — that teaches any compliant harness the memory golden path.
 
 **Website:** [yantrikdb.com](https://yantrikdb.com) · **Docs:** [yantrikdb.com/guides/mcp](https://yantrikdb.com/guides/mcp/) · **GitHub:** [yantrikos/yantrikdb-mcp](https://github.com/yantrikos/yantrikdb-mcp) · **Paper:** [Skill as Memory, Not Document](https://doi.org/10.5281/zenodo.20128887)
 
@@ -13,7 +13,7 @@ Works with Claude Code, Cursor, Windsurf, [Hermes Agent](docs/hermes.md), and an
 |---|---|
 | **What it is** | An MCP server that gives any MCP-compatible AI agent persistent, structured, queryable memory across sessions |
 | **Install** | `pip install yantrikdb-mcp` |
-| **Works with** | Claude Code, Cursor, Windsurf, Continue, Claude Desktop, [Hermes Agent](docs/hermes.md), any MCP client |
+| **Works with** | Claude Code, Cursor, Windsurf, Continue, Claude Desktop, [Hermes Agent](docs/hermes.md), [Prime Agent](docs/prime-agent.md), any MCP client |
 | **Storage** | Local SQLite at `~/.yantrikdb/memory.db` (or any path; or HTTP cluster) |
 | **Embedder** | Bundled 64-dim Rust embedder (default), 384-dim ONNX MiniLM (`[onnx]` extra), 256-dim multilingual (101 languages) |
 | **Tools** | 19 — remember, recall, forget, correct, think, memory, graph, conflict, trigger, session, temporal, procedure, category, personality, stats, skill, gaps, conversation, task |

--- a/docs/prime-agent.md
+++ b/docs/prime-agent.md
@@ -1,0 +1,103 @@
+# YantrikDB + Prime Agent — persistent semantic memory in the kernel
+
+[Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) persists its
+own harness state — system prompts, learned skills, sub-agent definitions —
+and that is exactly what it should persist. What it does not give you is a
+queryable memory: facts recalled by meaning rather than phrasing, beliefs
+revised without contradicting the old copy, memory shared with your *other*
+agents. YantrikDB adds that layer: semantic recall, typed memories, belief
+revision with history, contradiction detection, procedural learning, and
+time-travel recall — in a local SQLite file. No telemetry, no external
+services.
+
+Because Prime Agent runs tools as Python in a persistent IPython kernel,
+the integration is idiomatic there: `import yantrikdb; await
+yantrikdb.recall(...)`.
+
+## 1. Install and start the server
+
+Prime Agent's MCP bridge is HTTP-only (stdio servers are not wired through
+to the kernel yet), so run yantrikdb-mcp on the streamable-http transport:
+
+```bash
+pip install yantrikdb-mcp
+
+export YANTRIKDB_API_KEY=$(openssl rand -hex 16)
+yantrikdb-mcp --transport streamable-http --host 127.0.0.1 --port 8420
+```
+
+~10 MB, bundled Rust embedder, no native ML dependencies. The bearer token
+is required for network transports — the server refuses to run open.
+
+## 2. Declare the server
+
+Add to `~/.prime/agent/settings.json` (or project `.prime/agent/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "yantrikdb": {
+      "type": "http",
+      "url": "http://127.0.0.1:8420/mcp",
+      "bearerTokenEnvVar": "YANTRIKDB_API_KEY"
+    }
+  }
+}
+```
+
+## 3. Install the skill
+
+Copy [`integrations/prime-agent/yantrikdb/`](../integrations/prime-agent/yantrikdb/)
+into `~/.prime/agent/skills/`:
+
+```bash
+git clone --depth 1 https://github.com/yantrikos/yantrikdb-mcp
+cp -r yantrikdb-mcp/integrations/prime-agent/yantrikdb ~/.prime/agent/skills/
+```
+
+Launch Prime Agent with `YANTRIKDB_API_KEY` set in the same shell.
+
+## 4. Verify
+
+Ask Prime Agent to run, in its kernel:
+
+```python
+import yantrikdb
+r1 = await yantrikdb.remember(text="deploy window is Friday 6am", importance=0.8)
+r2 = await yantrikdb.recall(query="when do we deploy")
+print(r1, r2)
+```
+
+The `rid` returned by `remember` should appear in the `recall` results. If
+`import yantrikdb` raises `NotEnabled`, the `YANTRIKDB_API_KEY` variable is
+not visible to the Prime Agent process.
+
+## What we measured before publishing this
+
+Verified 2026-08-08 with prime-agent 0.7.1 (WSL Ubuntu), yantrikdb-mcp
+0.14.0, qwen3.8-max as the driving model, on a fresh database:
+
+- All 20 tools discovered via `await yantrikdb.list_tools()`.
+- `remember` returned `{"rid": "019fe43b-ee52-70ce-af71-df900b0024d8", "status": "recorded"}`.
+- `recall` on a paraphrased query returned that same rid, semantic score
+  0.72, with the marker text intact.
+- After packaging the `bearer_token_env` fix, the round-trip passed on the
+  first call of a fresh session, with no setup beyond the env var.
+
+## When you don't need this
+
+If one Prime Agent install on one machine is your whole setup and its own
+persistent state files cover what you want carried forward, they are the
+simpler tool — no server process to run. YantrikDB earns its keep when
+recall must survive paraphrase, when facts change and history matters, or
+when several harnesses (Prime Agent, Claude Code, Cursor, Hermes) should
+share one memory.
+
+## Notes
+
+- The skill module is named `yantrikdb`, the same name as the YantrikDB
+  Python package. Prime Agent's managed kernel venv does not include the
+  engine package, so there is no collision in a default setup; if you add
+  the engine to that venv yourself, rename one of them.
+- The database defaults to `~/.yantrikdb/memory.db`; point the server at a
+  different file with `YANTRIKDB_DB_PATH`.

--- a/integrations/prime-agent/yantrikdb/SKILL.md
+++ b/integrations/prime-agent/yantrikdb/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: yantrikdb
+description: Persistent cognitive memory via YantrikDB's MCP server. Semantic recall, remember, belief revision, knowledge graph, contradiction detection, and procedural learning that survive across sessions and agents. Tools are auto-discovered from the server at runtime.
+---
+
+# YantrikDB — persistent memory
+
+Talk to a YantrikDB memory server from the IPython kernel. Memory persists
+across sessions and across harnesses: what you `remember` here, a future
+session — or a different agent pointed at the same database — can `recall`.
+
+## Setup
+
+Requires a running yantrikdb-mcp server on the streamable-http transport:
+
+```bash
+YANTRIKDB_API_KEY=<your-token> yantrikdb-mcp --transport streamable-http --host 127.0.0.1 --port 8420
+```
+
+and the same `YANTRIKDB_API_KEY` value in Prime Agent's environment. The
+server URL defaults to `http://127.0.0.1:8420/mcp`; override it with a
+`yantrikdb` entry under `mcpServers` in `~/.prime/agent/settings.json`.
+
+## Usage
+
+Discover before you call — the server defines the tool set:
+
+```python
+import yantrikdb
+
+for tool in await yantrikdb.list_tools():
+    print(tool["name"], "-", tool["description"])
+
+# Store a durable fact
+await yantrikdb.remember(text="User prefers dark mode in the editor", importance=0.7)
+
+# Retrieve by meaning, not keywords
+hits = await yantrikdb.recall(query="what editor settings does the user like")
+print(hits)
+
+# Revise a fact without losing history (do NOT remember a contradiction)
+await yantrikdb.correct(query="editor preference", new_text="User switched to light mode", reason="user said so")
+```
+
+Notes:
+- Every tool is an `async` method — always `await`.
+- Results are already-parsed Python (a `dict` for structured output, otherwise a string).
+- Escape hatch for non-identifier tool names: `await yantrikdb.call_tool("name", {...})`.
+- If a call raises `NotEnabled`, the `YANTRIKDB_API_KEY` environment variable
+  is not visible to Prime Agent — set it in the shell that launches the agent.

--- a/integrations/prime-agent/yantrikdb/pyproject.toml
+++ b/integrations/prime-agent/yantrikdb/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "prime-agent-skill-yantrikdb"
+version = "0.1.0"
+description = "YantrikDB persistent-memory integration skill for Prime Agent."
+requires-python = ">=3.10"
+dependencies = ["mcp", "httpx", "prime-agent-runtime"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/yantrikdb"]

--- a/integrations/prime-agent/yantrikdb/src/yantrikdb/__init__.py
+++ b/integrations/prime-agent/yantrikdb/src/yantrikdb/__init__.py
@@ -1,0 +1,39 @@
+"""YantrikDB integration: persistent-memory tools auto-discovered from the MCP server.
+
+Usage in the kernel:
+
+    import yantrikdb
+    hits = await yantrikdb.recall(query="past decisions about the deploy")
+"""
+
+from __future__ import annotations
+
+from rlm import McpIntegration
+
+__all__ = ["YantrikDB", "yantrikdb"]
+
+
+class YantrikDB(McpIntegration):
+    server = "yantrikdb"
+    # Fallback when no mcpServers["yantrikdb"] entry exists in settings.json;
+    # the host config wins when present.
+    url = "http://127.0.0.1:8420/mcp"
+    # Without this every call raises NotEnabled: the host only injects OAuth
+    # tokens from auth.json, and yantrikdb-mcp uses a static bearer token.
+    bearer_token_env = "YANTRIKDB_API_KEY"
+
+
+yantrikdb = YantrikDB()
+
+# Names the kernel bootstrap probes to decide if a module is a callable skill.
+# Forwarding them would make `getattr(module, "run")` return an MCP tool stub
+# and the module would be wrapped as callable, breaking `await yantrikdb.<tool>()`.
+_RESERVED = {"run", "__wrapped__", "__call__"}
+
+
+def __getattr__(name: str):
+    # Forward bare module-level access (e.g. yantrikdb.recall) to the instance,
+    # so `import yantrikdb; await yantrikdb.recall(...)` works without `.yantrikdb`.
+    if name.startswith("_") or name in _RESERVED:
+        raise AttributeError(name)
+    return getattr(yantrikdb, name)


### PR DESCRIPTION
## What

- `integrations/prime-agent/yantrikdb/` — a Prime Agent Python skill (`McpIntegration` subclass) exposing all yantrikdb-mcp tools in the IPython kernel as `import yantrikdb; await yantrikdb.recall(...)`.
- `docs/prime-agent.md` — four-step guide (server → settings.json → skill → verify), plus what was measured and a "when you don''t need this" section.
- README: Prime Agent added to the works-with lines.

## Measured before shipping

Verified 2026-08-08, prime-agent 0.7.1 (WSL Ubuntu) + yantrikdb-mcp 0.14.0 + qwen3.8-max, fresh DB:

- 20/20 tools discovered via `list_tools()`.
- `remember` → `{"rid": "019fe43b-ee52-70ce-af71-df900b0024d8", "status": "recorded"}`.
- `recall` on a paraphrased query returned the same rid (score 0.72), marker text intact.
- Packaged skill passes first-call on a fresh session; the required line is `bearer_token_env = "YANTRIKDB_API_KEY"` (host injects OAuth from auth.json only; without it every call raises `NotEnabled`).

## Constraint stated in the docs

Prime Agent''s MCP bridge is HTTP-only — stdio entries are dropped — so the guide runs the server with `--transport streamable-http` and a bearer token. That is one more running process than the Claude Code path; the guide says so instead of hiding it.