### PR TITLE
registry: publish server.json to the official MCP registry via OIDC

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -1,0 +1,40 @@
+name: Publish to MCP Registry
+
+# Publishes server.json to the official MCP registry
+# (registry.modelcontextprotocol.io) using GitHub OIDC — no stored secrets.
+# Runs after each GitHub release, or manually via workflow_dispatch.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+
+      - name: Sync server.json version with release tag
+        if: github.event_name == 'release'
+        run: |
+          V="${GITHUB_REF_NAME#v}"
+          jq --arg v "$V" '.version = $v | .packages[0].version = $v' server.json > server.json.tmp
+          mv server.json.tmp server.json
+          echo "Publishing version $V"
+
+      - name: Login (GitHub OIDC)
+        run: mcp-publisher login github-oidc
+
+      - name: Publish
+        run: mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,21 +1,34 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.yantrikos/yantrikdb-mcp",
-  "description": "Cognitive memory for AI agents — semantic memory, knowledge graph, and adaptive recall",
+  "description": "Cognitive memory for AI agents — persistent semantic recall, knowledge graph, contradiction detection, and procedural learning",
   "repository": {
     "url": "https://github.com/yantrikos/yantrikdb-mcp",
     "source": "github"
   },
-  "version": "0.4.7",
+  "version": "0.14.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "yantrikdb-mcp",
-      "version": "0.4.7",
+      "version": "0.14.0",
       "transport": {
         "type": "stdio"
       },
-      "environmentVariables": []
+      "environmentVariables": [
+        {
+          "name": "YANTRIKDB_DB_PATH",
+          "description": "Database file path (default: ~/.yantrikdb/memory.db)",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "YANTRIKDB_TOOL_PROFILE",
+          "description": "Advertised tool set: full (all 20) or core (10 golden-path)",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
The official MCP registry (registry.modelcontextprotocol.io) has no yantrikdb entry: `server.json` was written at 0.4.7 and never published, while the README has carried the `mcp-name` marker all along.

- `server.json` → 0.14.0, canonical description, plus the two environment variables a consumer actually sets (`YANTRIKDB_DB_PATH`, `YANTRIKDB_TOOL_PROFILE`).
- New workflow `mcp-registry.yml`: publishes on each GitHub release (version synced from the tag via jq) and on manual dispatch. Auth is GitHub OIDC (`id-token: write`) — no stored secrets. The `io.github.yantrikos/*` namespace is proven by the workflow running in this org.
- Pre-verified: the PyPI 0.14.0 long description contains the `mcp-name` marker, which is what the registry checks for package ownership.

After merge I will dispatch the workflow once to backfill 0.14.0, then it rides every release.