### PR TITLE
registry: fit description into the schema's 100-char limit

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.yantrikos/yantrikdb-mcp",
-  "description": "Cognitive memory for AI agents — persistent semantic recall, knowledge graph, contradiction detection, and procedural learning",
+  "description": "Cognitive memory for AI agents — semantic recall, knowledge graph, and contradiction detection",
   "repository": {
     "url": "https://github.com/yantrikos/yantrikdb-mcp",
     "source": "github"


### PR DESCRIPTION
First dispatch of the publish workflow failed 422: body.description expected length <= 100, ours was 127. OIDC auth and package validation passed. This trims the description to 95 chars; re-dispatching after merge.