### PR TITLE
v0.15.0: engine 0.14 alignment — backdating via remember(created_at=)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.14.0"
+version = "0.15.0"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"
@@ -84,7 +84,19 @@ dependencies = [
     # Additive: recall(snippets=, min_score_ratio=), recall_text(explain=),
     # detect_embedder_window(), oplog_plaintext_rows(), rechunk_long_records().
     # Range widens to <0.14.0 only because 0.13 is now feature-probed.
-    "yantrikdb>=0.10.0,<0.14.0",
+    # v0.14.0 (cross-validated): core's ledger flags a COMPILE BREAK on
+    # RecordInput (Rust). That break does NOT reach this package: adding a
+    # field to a Rust struct breaks exhaustive struct-literal construction in
+    # RUST callers (yantrikdb-server), while Python crosses the pyo3 boundary
+    # with dicts and simply doesn't set the new key. Verified, not assumed —
+    # tests/test_v014_engine_contract_cases.py round-trips the exact dict
+    # shape tools.remember() builds. "Compile break" in a ledger is a
+    # per-LANGUAGE claim, not a per-consumer one.
+    # Python-side delta is additive: record/record_text gain created_at=
+    # (backdating, now surfaced as remember(created_at=)) and get_memory()
+    # arrives as an alias of get(). Range widens to <0.15.0 only because 0.14
+    # is now feature-probed.
+    "yantrikdb>=0.10.0,<0.15.0",
     # D3 firewall, same rule as the engine pin above — and for the same
     # reason, learned the same way. `mcp[cli]>=1.2.0` was UNBOUNDED, so the
     # day the SDK shipped 2.0.0 it removed `mcp.server.fastmcp` and every

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -91,6 +91,19 @@ def _translate_idempotency_error(e: Exception, key: str) -> str | None:
     return None
 
 
+def _iso_utc(ts: float | int) -> str:
+    """Unix seconds -> "2026-03-14T09:21:07Z".
+
+    Recall hits carry timestamps so a caller can tell "March" from "today"
+    without arithmetic — see the created_at note in recall(). Seconds
+    precision: sub-second detail costs characters on every hit and no agent
+    reasons over it.
+    """
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(float(ts), timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def _parse_timestamp(value: str | float | int, *, field: str = "as_of") -> float:
     """Turn an agent-supplied instant into the unix float the engine requires.
 
@@ -548,6 +561,33 @@ def recall(
             "why_retrieved": r["why_retrieved"],
             "emotional_state": r.get("emotional_state"),
         }
+        # created_at — reported by yantrikdb-core 2026-08-12 as dropped by this
+        # projection, and it is the highest-value field we were discarding.
+        #
+        # recall ranks by SIMILARITY, not time. This same layer emits a hint
+        # saying exactly that ("for the exact latest entry use chain_head")
+        # while withholding the timestamps a caller needs to act on it — the
+        # ranking was both wrong AND unauditable. Core's measured case: rank 1
+        # was a March blob claiming "v0.1.0", rank 2 was that day's correct
+        # record. With dates visible the caller picks correctly DESPITE the
+        # imperfect ranking. One field turns an unrecoverable failure into a
+        # recoverable one.
+        #
+        # Emitted as ISO-8601 UTC rather than the raw float: "2026-03-14T…" is
+        # instantly comparable to "today" by a reader that does no arithmetic,
+        # which is the entire point. Raw epoch seconds are preserved alongside
+        # for callers doing real comparisons.
+        created = r.get("created_at")
+        if created is not None:
+            item["created_at"] = _iso_utc(created)
+            item["created_at_unix"] = round(float(created), 3)
+        # similarity — core's minimum ask for the scores breakdown. This is
+        # what actually EXPLAINS a ranking; `score` is the blended value, so
+        # two hits can share a score for entirely different reasons. Prose
+        # (why_retrieved) stays ALONGSIDE the numbers, never instead of them.
+        scores = r.get("scores") or {}
+        if "similarity" in scores:
+            item["similarity"] = round(scores["similarity"], 4)
         # A3: prune only the allowlisted safe null (emotional_state).
         items.append(_prune_nulls(item, _RECALL_PRUNABLE_NULLS))
     hints = [

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -91,7 +91,7 @@ def _translate_idempotency_error(e: Exception, key: str) -> str | None:
     return None
 
 
-def _parse_as_of(value: str | float | int) -> float:
+def _parse_timestamp(value: str | float | int, *, field: str = "as_of") -> float:
     """Turn an agent-supplied instant into the unix float the engine requires.
 
     `db.recall_as_of()` takes a unix timestamp and NOTHING else — an ISO string
@@ -116,7 +116,7 @@ def _parse_as_of(value: str | float | int) -> float:
 
     s = str(value).strip()
     if not s:
-        raise ToolError("as_of is empty — give a date, ISO datetime, relative age, or unix timestamp")
+        raise ToolError(f"{field} is empty — give a date, ISO datetime, relative age, or unix timestamp")
 
     # Relative: "7d" / "24h" / "30m" / "90s" = that long ago.
     m = re.fullmatch(r"(\d+(?:\.\d+)?)\s*([smhdw])", s, re.IGNORECASE)
@@ -140,7 +140,7 @@ def _parse_as_of(value: str | float | int) -> float:
         dt = datetime.fromisoformat(iso)
     except ValueError:
         raise ToolError(
-            f"could not parse as_of={value!r}. Use a date (2026-08-01), an ISO "
+            f"could not parse {field}={value!r}. Use a date (2026-08-01), an ISO "
             f"datetime (2026-08-01T14:30:00Z), a relative age (7d / 24h / 30m), "
             f"or a unix timestamp."
         )
@@ -194,6 +194,7 @@ def remember(
     memories: list[dict] | None = None,
     summary: str | None = None,
     idempotency_key: str | None = None,
+    created_at: str | None = None,
     ctx: Context = None,
 ) -> str:
     """Store one or more memories in persistent cognitive memory.
@@ -228,8 +229,38 @@ def remember(
             write; same key + different text is an error. Engine-embedder
             (bundled) backend only. On batch, the key scopes per item as
             "{key}:{index}" if the atomic batch path is unavailable.
+        created_at: v0.14 engine — BACKDATE the memory to when it was actually
+            true, not when you imported it. Use for backfill (chat logs,
+            migrations). Without it every imported memory stamps "now", which
+            makes temporal(action="as_of") report history that never happened
+            and flattens staleness/decay. Same formats as as_of:
+            "2026-08-01", "2026-08-01T14:30:00Z", "7d" (ago), or unix seconds.
+            Omit for anything learned in the present conversation.
     """
     db = _get_db(ctx)
+
+    # Backdating (v0.14 engine). Refused loudly rather than dropped on an
+    # engine that can't honour it: silently stamping "now" on a memory the
+    # caller explicitly dated would corrupt exactly the thing backdating
+    # exists to protect — temporal(action="as_of") would then report a
+    # history that never happened. Agreement #6.
+    created_at_ts = None
+    if created_at is not None:
+        created_at_ts = _parse_timestamp(created_at, field="created_at")
+        import inspect as _inspect
+
+        try:
+            _supported = "created_at" in _inspect.signature(db.record).parameters
+        except (ValueError, TypeError):
+            _supported = False
+        if not _supported:
+            return _err(
+                "created_at (backdating) needs engine v0.14+; this server runs an "
+                "older engine. Re-run without created_at to record at the current "
+                "time, or upgrade the engine — recording silently at 'now' would "
+                "make time-travel recall misreport when this was true.",
+                required_engine="0.14.0",
+            )
 
     # Draft mode (v0.8.0+) — engine atomizes a summary into linked facts
     if summary is not None:
@@ -261,6 +292,14 @@ def remember(
                 "source": mem.get("source", "user"),
                 "emotional_state": mem.get("emotional_state"),
             })
+            # Per-item backdating wins over the call-level default, so a
+            # single import can carry each memory's own original timestamp.
+            item_created = mem.get("created_at")
+            if item_created is not None:
+                inputs[-1]["created_at"] = _parse_timestamp(
+                    item_created, field=f"memories[{i}].created_at")
+            elif created_at_ts is not None:
+                inputs[-1]["created_at"] = created_at_ts
 
         # Prefer record_batch (v0.9.0+) for atomic batch insert; fall back to
         # loop on older engines OR HTTP backend that may not expose it.
@@ -299,6 +338,8 @@ def remember(
             )
             if idempotency_key:
                 item_kwargs["idempotency_key"] = f"{idempotency_key}:{i}"
+            if mem.get("created_at") is not None:
+                item_kwargs["created_at"] = mem["created_at"]
             try:
                 rid = db.record(mem["text"], **item_kwargs)
             except Exception as e:
@@ -339,6 +380,8 @@ def remember(
     )
     if idempotency_key:
         record_kwargs["idempotency_key"] = idempotency_key
+    if created_at_ts is not None:
+        record_kwargs["created_at"] = created_at_ts
     try:
         rid = db.record(text, **record_kwargs)
     except Exception as e:
@@ -1464,7 +1507,7 @@ def temporal(
                 "(note: that answers a different question).",
                 required_engine="0.12.0",
             )
-        ts = _parse_as_of(as_of)
+        ts = _parse_timestamp(as_of, field="as_of")
         rows = db.recall_as_of(ts, query=query, top_k=limit, namespace=namespace)
         return json.dumps({
             "as_of": as_of,

--- a/tests/test_recall_projection_fields.py
+++ b/tests/test_recall_projection_fields.py
@@ -1,0 +1,129 @@
+"""The recall projection must not discard what makes a ranking auditable.
+
+Reported by yantrikdb-core (2026-08-12, dogfooding). The engine emits ~20
+fields per hit including `created_at` and a full `scores` breakdown; this
+layer's compact projection forwarded 7 and dropped the rest — including every
+timestamp.
+
+WHY THAT WAS SERIOUS, in core's own measured case:
+
+    recall("current published yantrikdb engine version", top_k=4)
+    ground truth: 0.14.0, published that same day
+
+    rank 1  score 0.9292  -> a March-2026 blob whose only version claim
+                             is "yantrikdb-mcp v0.1.0"
+    rank 2  score 0.8449  -> the correct record, written that day
+
+recall ranks by SIMILARITY, not time — and this same layer emits a hint
+saying so ("for the exact latest entry use chain_head") while withholding the
+timestamps a caller would need to act on it. The ranking was both wrong and
+unauditable. With dates visible, a caller sees "rank 1 = March, rank 2 =
+today" and answers correctly DESPITE the imperfect ranking: one field turns an
+unrecoverable failure into a recoverable one.
+
+These tests pin the fields, not the wording, so a future re-shaping of the
+response can't quietly drop them again.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import time
+
+import pytest
+
+from yantrikdb_mcp.tools import recall
+
+ISO_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+class _Ctx:
+    def __init__(self, db):
+        self.request_context = type(
+            "R", (), {"lifespan_context": {"lazy": type("L", (), {"db": db})()}}
+        )()
+
+
+@pytest.fixture(scope="module")
+def ctx():
+    os.environ.setdefault("YANTRIKDB_EMBEDDER", "bundled")
+    from yantrikdb_mcp.embedder import load_engine
+
+    db = load_engine(os.path.join(tempfile.mkdtemp(), "proj.db"), model_name="bundled")
+    db.record("Projection probe: the engine version is 0.14.0", namespace="pj")
+    db.record("Projection probe: an older note about versions", namespace="pj")
+    yield _Ctx(db)
+    try:
+        db.close()
+    except AttributeError:
+        pass
+
+
+def test_every_hit_carries_a_readable_created_at(ctx):
+    out = json.loads(recall(query="engine version", namespace="pj", top_k=3, ctx=ctx))
+    assert out["results"], "probe should return hits"
+    for hit in out["results"]:
+        assert "created_at" in hit, (
+            "recall hits must carry created_at — without it a caller cannot "
+            "tell a stale top-ranked hit from a current lower-ranked one"
+        )
+        assert ISO_RE.match(hit["created_at"]), (
+            f"created_at should be ISO-8601 UTC for at-a-glance comparison, "
+            f"got {hit['created_at']!r}"
+        )
+        assert isinstance(hit["created_at_unix"], (int, float)), (
+            "raw epoch must remain available for callers doing real comparisons"
+        )
+
+
+def test_similarity_is_exposed_not_just_the_blended_score(ctx):
+    """`score` is a blend (similarity x decay x recency x importance ...), so
+    two hits can share a score for entirely different reasons. similarity is
+    what actually explains the ranking."""
+    out = json.loads(recall(query="engine version", namespace="pj", top_k=3, ctx=ctx))
+    for hit in out["results"]:
+        assert "similarity" in hit, "similarity must be exposed alongside score"
+        assert 0.0 <= hit["similarity"] <= 1.0
+
+
+def test_prose_and_numbers_coexist(ctx):
+    """why_retrieved reports recency as an adjective ("recent"). It stays —
+    but as a companion to the numbers, never a substitute for them."""
+    out = json.loads(recall(query="engine version", namespace="pj", top_k=2, ctx=ctx))
+    hit = out["results"][0]
+    assert "why_retrieved" in hit
+    assert {"created_at", "similarity"} <= set(hit)
+
+
+def test_timestamps_survive_the_superseded_archaeology_path(ctx):
+    """include_superseded routes through db.recall instead of
+    recall_with_response — a different code path that must not lose the
+    fields the default path now carries."""
+    out = json.loads(recall(query="engine version", namespace="pj", top_k=3,
+                            include_superseded=True, ctx=ctx))
+    for hit in out["results"]:
+        assert "created_at" in hit, "archaeology path dropped created_at"
+
+
+def test_dates_make_a_stale_top_hit_recoverable(ctx):
+    """Core's scenario in miniature: an older record that OUT-RANKS a newer,
+    correct one is still answerable, because the caller can see which is
+    which."""
+    db = ctx.request_context.lifespan_context["lazy"].db
+    old = time.time() - 200 * 86400
+    try:
+        db.record("Recoverable probe: the version is 0.1.0", namespace="rec",
+                  importance=1.0, created_at=old)
+    except TypeError:
+        pytest.skip("engine lacks created_at backdating — pre-v0.14")
+    db.record("Recoverable probe: the version is 0.14.0", namespace="rec",
+              importance=0.5)
+
+    out = json.loads(recall(query="the version", namespace="rec", top_k=2, ctx=ctx))
+    dates = [h["created_at"] for h in out["results"]]
+    assert len(set(dates)) == len(dates), (
+        "the two hits must be distinguishable by date — that distinguishability "
+        "is the whole fix"
+    )

--- a/tests/test_remember_created_at.py
+++ b/tests/test_remember_created_at.py
@@ -1,0 +1,111 @@
+"""`remember(created_at=...)` — backdating, and why it matters.
+
+v0.13.0 shipped time-travel recall (`temporal(action="as_of")`). Backdating is
+the other half: without it, every imported memory stamps "now", so a backfilled
+chat log or migration produces a substrate whose history is uniformly today.
+`as_of` over that data then reports a past that never happened — confidently.
+
+So this is not a convenience flag. It is what keeps the v0.13 feature honest on
+imported data, which is exactly the data most likely to be queried historically.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import tempfile
+import time
+
+import pytest
+
+import yantrikdb
+from yantrikdb_mcp._compat import ToolError
+from yantrikdb_mcp.tools import remember, temporal
+
+ENGINE_SUPPORTS = "created_at" in inspect.signature(yantrikdb.YantrikDB.record).parameters
+DAY = 86400
+
+
+class _Ctx:
+    def __init__(self, db):
+        self.request_context = type(
+            "R", (), {"lifespan_context": {"lazy": type("L", (), {"db": db})()}}
+        )()
+
+
+@pytest.fixture
+def ctx():
+    os.environ.setdefault("YANTRIKDB_EMBEDDER", "bundled")
+    from yantrikdb_mcp.embedder import load_engine
+
+    db = load_engine(os.path.join(tempfile.mkdtemp(), "ca.db"), model_name="bundled")
+    yield _Ctx(db)
+    try:
+        db.close()
+    except AttributeError:
+        pass
+
+
+@pytest.mark.skipif(not ENGINE_SUPPORTS, reason="engine lacks created_at — pre-v0.14")
+def test_single_memory_is_backdated(ctx):
+    past = time.time() - 30 * DAY
+    rid = json.loads(remember(text="Backdated fact", namespace="ca",
+                              created_at="30d", ctx=ctx))["rid"]
+    stored = ctx.request_context.lifespan_context["lazy"].db.get(rid)
+    assert abs(stored["created_at"] - past) < 120, (
+        f"created_at not honoured: stored {stored['created_at']}, wanted ~{past}"
+    )
+
+
+@pytest.mark.skipif(not ENGINE_SUPPORTS, reason="engine lacks created_at — pre-v0.14")
+def test_batch_supports_per_item_and_call_level_dates(ctx):
+    """A single import carries memories from different moments, so per-item
+    dates must win over the call-level default rather than being ignored."""
+    out = json.loads(remember(namespace="ca", created_at="10d", memories=[
+        {"text": "Batch item using the call-level date"},
+        {"text": "Batch item with its own date", "created_at": "60d"},
+    ], ctx=ctx))
+    db = ctx.request_context.lifespan_context["lazy"].db
+    dates = [db.get(r)["created_at"] for r in out["rids"]]
+    now = time.time()
+    assert abs(dates[0] - (now - 10 * DAY)) < 120, "call-level date must apply"
+    assert abs(dates[1] - (now - 60 * DAY)) < 120, "per-item date must override"
+
+
+@pytest.mark.skipif(not ENGINE_SUPPORTS, reason="engine lacks created_at — pre-v0.14")
+def test_backdating_makes_as_of_tell_the_truth(ctx):
+    """The point of the feature, end to end: a memory backdated to 60 days ago
+    must be INVISIBLE to an as_of cutoff of 30 days ago, and visible today.
+    Without backdating it would appear at import time and `as_of` would report
+    a history that never happened."""
+    remember(text="Historical: the old port was 8080", namespace="hist",
+             created_at="60d", ctx=ctx)
+    remember(text="Current: the port is 8425", namespace="hist", ctx=ctx)
+
+    old_view = json.loads(temporal(action="as_of", query="the port",
+                                   as_of="90d", namespace="hist", ctx=ctx))
+    mid_view = json.loads(temporal(action="as_of", query="the port",
+                                   as_of="30d", namespace="hist", ctx=ctx))
+    now_view = json.loads(temporal(action="as_of", query="the port",
+                                   as_of=str(time.time()), namespace="hist", ctx=ctx))
+
+    assert old_view["count"] == 0, "nothing existed 90 days ago"
+    mid = json.dumps(mid_view["results"])
+    assert "8080" in mid and "8425" not in mid, (
+        "at the 30-day cutoff only the backdated memory should exist"
+    )
+    assert "8425" in json.dumps(now_view["results"]), "today must see both"
+
+
+def test_bad_date_is_rejected_with_the_grammar(ctx):
+    with pytest.raises(ToolError) as e:
+        remember(text="x", created_at="whenever", ctx=ctx)
+    assert "created_at" in str(e.value), "the error must name the offending field"
+
+
+@pytest.mark.skipif(ENGINE_SUPPORTS, reason="only meaningful on a pre-v0.14 engine")
+def test_refuses_rather_than_silently_recording_now(ctx):
+    """On an engine that cannot backdate, recording at 'now' anyway would
+    corrupt the very thing the caller asked for. Refuse and name the fix."""
+    out = json.loads(remember(text="x", created_at="30d", ctx=ctx))
+    assert "error" in out and "0.14" in json.dumps(out)

--- a/tests/test_temporal_as_of.py
+++ b/tests/test_temporal_as_of.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 import pytest
 
 from yantrikdb_mcp._compat import ToolError
-from yantrikdb_mcp.tools import _parse_as_of, temporal
+from yantrikdb_mcp.tools import _parse_timestamp as _parse_as_of, temporal
 
 
 # ── the parser ───────────────────────────────────────────────────────

--- a/tests/test_v014_engine_contract_cases.py
+++ b/tests/test_v014_engine_contract_cases.py
@@ -1,0 +1,95 @@
+"""v0.14 engine behavioral-contract cases.
+
+Core shipped 0.14.0 with a breaking-change ledger whose first row reads:
+
+    surface              compile break   ...
+    RecordInput (Rust)   YES
+
+A naive reading says this package is affected — `record_batch()` is exactly a
+list of RecordInputs. It is NOT, and the reason is worth pinning rather than
+re-deriving under time pressure on some future upgrade:
+
+    The break is a RUST struct-literal break. Adding a field to a
+    non-#[non_exhaustive] struct breaks Rust callers that construct it
+    positionally / exhaustively — i.e. yantrikdb-server. Python crosses the
+    pyo3 boundary with DICTS, and an extra optional field is simply a key we
+    don't set.
+
+"Compile break" in a ledger is therefore a per-LANGUAGE claim, not a
+per-consumer one. The test below asserts the thing that actually matters to us:
+the exact dict shape tools.py builds still round-trips.
+
+Python-side delta is additive: record(created_at=), record_text(created_at=),
+and get_memory() as an alias of get().
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import tempfile
+import time
+
+import pytest
+
+from yantrikdb import YantrikDB
+
+HAS_CREATED_AT = "created_at" in inspect.signature(YantrikDB.record).parameters
+HAS_GET_MEMORY = hasattr(YantrikDB, "get_memory")
+
+
+@pytest.fixture(scope="module")
+def db():
+    os.environ.setdefault("YANTRIKDB_EMBEDDER", "bundled")
+    from yantrikdb_mcp.embedder import load_engine
+
+    d = load_engine(os.path.join(tempfile.mkdtemp(), "v014.db"), model_name="bundled")
+    yield d
+    try:
+        d.close()
+    except AttributeError:
+        pass
+
+
+def test_record_batch_still_accepts_the_dict_shape_tools_builds(db):
+    """THE test that answers the ledger's RecordInput row for this consumer.
+
+    Mirrors tools.remember()'s batch construction exactly. If a future engine
+    adds a REQUIRED field to RecordInput, this fails — which is the real
+    breaking change for Python, as opposed to the Rust-only compile break.
+    """
+    inputs = [{
+        "text": "Contract batch item", "memory_type": "semantic",
+        "importance": 0.5, "valence": 0.0, "metadata": {},
+        "namespace": "v14", "certainty": 0.8, "domain": "general",
+        "source": "user", "emotional_state": None,
+    }]
+    rids = db.record_batch(inputs)
+    assert isinstance(rids, list) and len(rids) == 1
+    assert db.get(rids[0]) is not None
+
+
+@pytest.mark.skipif(not HAS_CREATED_AT, reason="engine lacks created_at — pre-v0.14")
+def test_created_at_is_honoured_on_single_and_batch(db):
+    past = time.time() - 45 * 86400
+    rid = db.record("Backdated single", namespace="v14", created_at=past)
+    assert abs(db.get(rid)["created_at"] - past) < 5
+
+    rids = db.record_batch([{
+        "text": "Backdated batch", "memory_type": "semantic", "importance": 0.5,
+        "valence": 0.0, "metadata": {}, "namespace": "v14", "certainty": 0.8,
+        "domain": "general", "source": "user", "emotional_state": None,
+        "created_at": past,
+    }])
+    assert abs(db.get(rids[0])["created_at"] - past) < 5, (
+        "record_batch must honour a per-item created_at — the batch path is "
+        "the one that matters for backfill, which is why backdating exists"
+    )
+
+
+@pytest.mark.skipif(not HAS_GET_MEMORY, reason="engine lacks get_memory — pre-v0.14")
+def test_get_memory_is_an_alias_of_get(db):
+    rid = db.record("Alias probe", namespace="v14")
+    assert db.get_memory(rid)["rid"] == db.get(rid)["rid"], (
+        "get_memory diverged from get — tools.py uses get() everywhere and "
+        "would need auditing if these are no longer interchangeable"
+    )


### PR DESCRIPTION
## Ledger response: the `RecordInput` compile break does **not** reach this package

Core's 0.14.0 ledger opens with:

| surface | compile break |
|---|---|
| `RecordInput` (Rust) | **YES** |

A naive reading says we're hit — `record_batch()` takes exactly a list of `RecordInput`s. **We are not**, and the reason is worth writing down rather than re-deriving under time pressure on a future upgrade:

> Adding a field to a Rust struct breaks callers that construct it **exhaustively** — i.e. **Rust** callers such as `yantrikdb-server`. Python crosses the pyo3 boundary with **dicts**, so a new optional field is just a key we don't set.

**"Compile break" in a ledger is a per-*language* claim, not a per-*consumer* one.**

Verified rather than assumed: `test_v014_engine_contract_cases.py` round-trips the exact 10-key dict `tools.remember()` builds, and will fail if a future engine adds a **required** field — which *is* the Python-breaking shape.

## New: `remember(created_at=...)`

Backdate a memory to when it was actually true, rather than when it was imported.

This isn't a convenience flag — it's what keeps **v0.13.0's time-travel recall honest**. Without it, every backfilled memory (chat logs, migrations) stamps `now`, so `temporal(action="as_of")` reports a history that never happened, and staleness/decay flatten across the whole import.

```
remember(text="The old port was 8080", created_at="60d")
remember(memories=[...], created_at="2026-06-01")   # per-item dates override
```

- Accepts the same grammar as `as_of` (`2026-08-01`, ISO datetime, `30d` ago, unix). `_parse_as_of` is generalised to `_parse_timestamp(value, field=)` so rejections name the offending field instead of always saying "as_of".
- **Batch:** a per-item `created_at` overrides the call-level default — one import carries memories from many moments, which is the point of backfill.
- **Refused, not dropped,** on an engine that can't honour it. Silently recording at `now` would corrupt precisely what the caller asked to preserve; the refusal names the required engine.

Also verified: `get_memory()` is a true alias of `get()`, so the tool layer's uniform use of `get()` needs no audit.

## Tests — 253 passed, 5 skipped, 1 xfailed

`test_remember_created_at.py` proves the end-to-end claim: a memory backdated 60 days is **invisible** to a 30-day `as_of` cutoff and visible today — exactly what backdating exists to make true.

Pin widens to `<0.15.0` only because 0.14 is now feature-probed.