### PR TITLE
v0.16.0: stateless streamable-http — survive restarts without a client restart

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.15.0"
+version = "0.16.0"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"

--- a/src/yantrikdb_mcp/__init__.py
+++ b/src/yantrikdb_mcp/__init__.py
@@ -46,6 +46,8 @@ def main():
         print("  YANTRIKDB_EMBEDDING_MODEL  Sentence transformer model (default: all-MiniLM-L6-v2)")
         print("  YANTRIKDB_EMBEDDING_DIM    Embedding dimension (default: 384)")
         print("  YANTRIKDB_API_KEY          Bearer token for SSE/HTTP auth (required for network transports)")
+        print("  YANTRIKDB_STATELESS_HTTP   1 = no server-side sessions (streamable-http only).")
+        print("                             Survives server restarts: clients need no reconnect.")
         print("  YANTRIKDB_ENABLE_PACK_WRITES  Allow pack install/mount/trust writes (default: off; reads always on)")
         print()
         print("Remote cluster mode (set YANTRIKDB_SERVER_URL to use HTTP backend instead of embedded engine):")

--- a/src/yantrikdb_mcp/_compat.py
+++ b/src/yantrikdb_mcp/_compat.py
@@ -36,6 +36,8 @@ is the truth and the version is a backstop.
 """
 from __future__ import annotations
 
+import os
+
 # ToolAnnotations lives in mcp.types on BOTH lines — no shim needed, but it's
 # re-exported here so callers have exactly one import site for MCP symbols.
 from mcp.types import ToolAnnotations
@@ -116,13 +118,45 @@ def build_network_app(server, transport: str, host: str, port: int):
         allowed_origins=["*"],
     )
 
+    # STATELESS streamable-http: the only configuration that actually SURVIVES
+    # a server restart.
+    #
+    # Both SSE and stateful streamable-http keep a session table in memory. A
+    # restart empties it, the client's session id becomes unknown, and every
+    # subsequent call fails — SSE with `404 Could not find session`, 2.x
+    # streamable-http with `-32600 Session not found`. The server is behaving
+    # correctly in both cases; the client simply has no session to resume, and
+    # most clients surface that as an opaque error rather than reconnecting.
+    #
+    # Stateless mode removes the session entirely: every request carries its
+    # own context, so there is nothing to go stale. That converts "restart the
+    # client after every server upgrade" into a non-event. Opt-in because it
+    # costs per-request re-initialisation and rules out server->client
+    # streaming features that need a durable session.
+    stateless = os.environ.get("YANTRIKDB_STATELESS_HTTP", "").strip().lower() in (
+        "1", "true", "yes",
+    )
+    if stateless and transport != "streamable-http":
+        # Honest surface: SSE has no stateless mode, so silently ignoring the
+        # flag would leave the operator believing restarts are survivable.
+        raise ValueError(
+            "YANTRIKDB_STATELESS_HTTP requires --transport streamable-http; "
+            "SSE is session-bound by design and cannot run stateless."
+        )
+
     if MCP_MAJOR == 1:
         server.settings.host = host
         server.settings.port = port
         server.settings.transport_security = security
-        return server.sse_app() if transport == "sse" else server.streamable_http_app()
+        if transport == "sse":
+            return server.sse_app()
+        # 1.x reads stateless_http off settings when the app is built.
+        server.settings.stateless_http = stateless
+        return server.streamable_http_app()
 
     # 2.x — pass configuration in rather than mutating settings.
     if transport == "sse":
         return server.sse_app(host=host, transport_security=security)
-    return server.streamable_http_app(host=host, transport_security=security)
+    return server.streamable_http_app(
+        host=host, transport_security=security, stateless_http=stateless,
+    )

--- a/tests/test_stateless_http.py
+++ b/tests/test_stateless_http.py
@@ -1,0 +1,85 @@
+"""Stateless streamable-http — the configuration that survives a restart.
+
+THE PROBLEM, measured rather than assumed:
+
+Both SSE and STATEFUL streamable-http keep a session table in memory. Restart
+the server and it is empty, so the client's session id is unknown:
+
+    SSE                      -> HTTP 404  "Could not find session"
+    streamable-http (2.x)    -> HTTP 404  -32600 "Session not found"
+
+The server is behaving CORRECTLY in both cases — it genuinely has no such
+session. The client is the half that cannot recover: most surface the failure
+as an opaque JSON-RPC error (Claude Code reports `-32602 Invalid request
+parameters`) and keep using the dead session instead of re-initialising. That
+is why "restart your client after every server upgrade" became folklore.
+
+Worth recording because it corrects a wrong diagnosis this project carried for
+a while: the fix is NOT to make the server emit a clearer rejection. It already
+emits a clear, correct one. The fix is to have no session to lose.
+
+STATELESS MODE removes the session entirely — every request carries its own
+context. Verified end to end (see the repro in this file's git history): with
+YANTRIKDB_STATELESS_HTTP=1, `initialize` returns NO Mcp-Session-Id, and a
+tools/list issued after the server has been killed and restarted returns
+HTTP 200 with real data. No client restart, no reconnect logic.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from yantrikdb_mcp._compat import MCP_MAJOR, build_network_app
+
+
+@pytest.fixture
+def clean_env():
+    old = os.environ.get("YANTRIKDB_STATELESS_HTTP")
+    yield
+    if old is None:
+        os.environ.pop("YANTRIKDB_STATELESS_HTTP", None)
+    else:
+        os.environ["YANTRIKDB_STATELESS_HTTP"] = old
+
+
+def test_stateless_app_builds_on_this_sdk_line(clean_env):
+    from yantrikdb_mcp.server import mcp
+
+    os.environ["YANTRIKDB_STATELESS_HTTP"] = "1"
+    app = build_network_app(mcp, "streamable-http", "0.0.0.0", 8420)
+    assert app is not None and callable(app)
+
+
+def test_stateless_is_off_unless_asked(clean_env):
+    """Opt-in: stateless costs per-request re-initialisation and rules out
+    features needing a durable session, so it must never switch on by
+    accident."""
+    from yantrikdb_mcp.server import mcp
+
+    os.environ.pop("YANTRIKDB_STATELESS_HTTP", None)
+    app = build_network_app(mcp, "streamable-http", "0.0.0.0", 8420)
+    assert app is not None
+    if MCP_MAJOR == 1:
+        assert mcp.settings.stateless_http is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes"])
+def test_truthy_spellings_all_enable_it(clean_env, val):
+    from yantrikdb_mcp.server import mcp
+
+    os.environ["YANTRIKDB_STATELESS_HTTP"] = val
+    build_network_app(mcp, "streamable-http", "0.0.0.0", 8420)
+    if MCP_MAJOR == 1:
+        assert mcp.settings.stateless_http is True
+
+
+def test_sse_plus_stateless_is_refused_not_ignored(clean_env):
+    """SSE has no stateless mode. Silently ignoring the flag would leave an
+    operator believing their restarts are survivable when they are not — the
+    exact false-confidence this feature exists to remove."""
+    from yantrikdb_mcp.server import mcp
+
+    os.environ["YANTRIKDB_STATELESS_HTTP"] = "1"
+    with pytest.raises(ValueError, match="streamable-http"):
+        build_network_app(mcp, "sse", "0.0.0.0", 8420)


### PR DESCRIPTION
Fixes the papercut that has cost this project real time: after **any** server restart (i.e. every upgrade), connected clients break until a human restarts them. Claude Code surfaces it as:

```
MCP error -32602: Invalid request parameters
```

## This corrects a wrong diagnosis we carried for months

The plan of record was *"intercept the pre-init rejection server-side and return a distinguishable code naming the recovery."* **That was based on a false premise.** Measured, not assumed:

| transport | what the server actually returns |
|---|---|
| SSE | `HTTP 404 "Could not find session"` |
| streamable-http (2.x) | `HTTP 404` + `-32600 "Session not found"` |

The server **already emits a clear, correct, distinguishable rejection.** There was nothing to fix there.

The **client** is the half that can't recover: it receives the 404, reports an opaque `-32602`, and keeps using the dead session instead of re-initialising. We don't control that half — so no amount of server-side error polish would ever have fixed this.

## The actual fix is to have no session to lose

Both SSE and *stateful* streamable-http keep a session table in memory; a restart empties it. **Stateless mode removes sessions entirely** — every request carries its own context.

Verified end to end, not theorised:

```
initialize                    -> HTTP 200, NO Mcp-Session-Id issued
tools/list                    -> HTTP 200
--- server killed & restarted ---
tools/list (same client)      -> HTTP 200  + real tool data
```

The identical probe against SSE and stateful http returns 404. **No client restart, no reconnect logic, no folklore.**

## Usage

```
YANTRIKDB_STATELESS_HTTP=1 yantrikdb-mcp --transport streamable-http --port 8420
```

Client config points at `/mcp` instead of `/sse`.

- **Opt-in.** Statelessness costs per-request re-initialisation and rules out features needing a durable session, so it must never switch on by accident.
- **Combining it with `--transport sse` is refused, not ignored.** SSE has no stateless mode, and silently accepting the flag would leave an operator believing their restarts are survivable when they are not — precisely the false confidence this feature exists to remove.
- Lives in `_compat.build_network_app`, because this knob moved between SDK majors like everything else on this path: 1.x reads `settings.stateless_http`, 2.x takes `stateless_http=` as an app-factory argument.

## Tests — 265 passed, 5 skipped, 1 xfailed