### PR TITLE
v0.17.0: require engine >=0.14.1 — retrieval correctness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.16.0"
+version = "0.17.0"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"
@@ -96,7 +96,27 @@ dependencies = [
     # (backdating, now surfaced as remember(created_at=)) and get_memory()
     # arrives as an alias of get(). Range widens to <0.15.0 only because 0.14
     # is now feature-probed.
-    "yantrikdb>=0.10.0,<0.15.0",
+    # v0.14.1 is the FLOOR, not merely allowed — the first time this package
+    # has raised a lower bound for a CORRECTNESS reason rather than to reach a
+    # feature. 0.14.0 and earlier return wrong results specifically through
+    # THIS server, and only through it:
+    #   - The entity stoplist compared case-SENSITIVELY against capitalized
+    #     forms, so "At" was stripped while "AT" survived and became an entity.
+    #     tokenize() lowercases it, so the phantom entity matched EVERY query
+    #     containing the word "at". Likewise THE, DID, and June.
+    #   - Graph proximity was ADDITIVE (0.30 floor), which no similarity below
+    #     0.86 could overcome. Now scaled to 0.125 — graph may reverse at most
+    #     a 12.5% similarity gap, the same ceiling freshness gets.
+    # These were invisible to core's benchmark because expand_entities defaults
+    # to FALSE in the engine and this server turns it ON. Reproduced on a
+    # 5,027-record production store: "encryption at rest and key rotation"
+    # returned a REAL-ESTATE TAX ANALYSIS at cosine 0.0346, joined by
+    # "claims_match: AT -acquired-> 25 (anchor AT)". On 0.14.1 that record is
+    # gone from the top 5 and every phantom anchor with it.
+    # Ranking DOES move — that is the point — so the floor is safe here only
+    # because our cases gate on feature probes, never on golden orderings
+    # (265 passed unchanged against 0.14.1).
+    "yantrikdb>=0.14.1,<0.15.0",
     # D3 firewall, same rule as the engine pin above — and for the same
     # reason, learned the same way. `mcp[cli]>=1.2.0` was UNBOUNDED, so the
     # day the SDK shipped 2.0.0 it removed `mcp.server.fastmcp` and every


### PR DESCRIPTION
Raises the engine **floor**, rather than widening the ceiling as every prior pin change did. It is the first time this package has raised a lower bound for **correctness** instead of to reach a feature, which is why the pin comment grew.

## Why 0.14.0 is not good enough

Two engine defects that produced wrong results **through this server, and essentially only through it**:

- The entity stoplist compared **case-sensitively** against capitalized forms. `"At"` was stripped; `"AT"` survived and became an entity. `tokenize()` lowercases it, so the phantom entity matched **every query containing the word "at."** Same for `THE`, `DID`, and `June`.
- Graph proximity was **additive** — a 0.30 floor that no similarity below 0.86 could overcome. Now scaled to 0.125, so graph may reverse at most a 12.5% similarity gap, the same ceiling freshness gets.

Both were invisible to the engine's own benchmark because `expand_entities` defaults to `False` there and **this server turns it on**. The benchmark was certifying a configuration production does not use.

## Reproduced, then re-measured

On a 5,027-record production store, before upgrading:

```
query:  "encryption at rest and key rotation"
rank 5: a real-estate tax analysis, similarity 0.0346
why:    claims_match: AT -acquired-> 25 (anchor AT)
        graph-connected via June
```

Same store, minutes later on 0.14.1: that record is **gone from the top 5**, every phantom anchor with it, and the four relevant records keep their relative order. Scores compress as expected from the graph rescale (0.598 → 0.482).

## The risk worth naming

**Ranking moves by design.** A suite asserting golden orderings would light up here. Ours does not — every case gates on a feature probe (`hasattr` / signature / raised-type), never a version parse or a fixed rank. **265 passed, unchanged.**

## Not fixed by this, and not claimed

`"current published engine version"` still returns stale consolidated records. That is authoring plus ranking design — no record carries the word "current" beside a version, and `similarity × importance × decay` has no notion of "latest." `chain_head` remains the right tool for current-value questions. Flagged upstream so the fix does not get credit for it.

## Version

**0.17.0, not 0.16.1** — a floor raise narrows what consumers can install.