### PR TITLE
v0.18.0: forward what you accept, refuse what you cannot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.17.0"
+version = "0.18.0"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"
@@ -116,7 +116,14 @@ dependencies = [
     # Ranking DOES move — that is the point — so the floor is safe here only
     # because our cases gate on feature probes, never on golden orderings
     # (265 passed unchanged against 0.14.1).
-    "yantrikdb>=0.14.1,<0.15.0",
+    # v0.18.0 REQUIRES >=0.15.0: think(maintenance_cycle, dry_run) now
+    # forwards dry_run to the binding, and pre-0.15 engines have no such
+    # parameter — the call raises TypeError there BY DESIGN (a "preview"
+    # must never silently run wet; that exact incident tombstoned 13 live
+    # records on the production store). The recall/think field forwarding
+    # in this release likewise lands on an engine that actually reads the
+    # fields. 266 passed against the published 0.15.0 wheel.
+    "yantrikdb>=0.15.0,<0.16.0",
     # D3 firewall, same rule as the engine pin above — and for the same
     # reason, learned the same way. `mcp[cli]>=1.2.0` was UNBOUNDED, so the
     # day the SDK shipped 2.0.0 it removed `mcp.server.fastmcp` and every

--- a/src/yantrikdb_mcp/http_backend.py
+++ b/src/yantrikdb_mcp/http_backend.py
@@ -190,6 +190,13 @@ class HttpBackend:
                              expand_entities=True, namespace=None,
                              domain=None, source=None) -> dict:
         body: dict = {"query": query, "top_k": top_k}
+        # These two were accepted and silently dropped — recall(
+        # expand_entities=...) / include_consolidated=True did nothing on
+        # cluster while working embedded. Forward both; a server that
+        # ignores unknown body fields behaves exactly as before, one that
+        # honors them now honors the caller.
+        body["include_consolidated"] = include_consolidated
+        body["expand_entities"] = expand_entities
         if memory_type:
             body["memory_type"] = memory_type
         if namespace:
@@ -230,6 +237,13 @@ class HttpBackend:
         surfaces via the why_retrieved/superseded_by fields being absent
         rather than silently — the row shape itself is identical)."""
         body: dict = {"query": query, "top_k": top_k}
+        # These two were accepted and silently dropped — recall(
+        # expand_entities=...) / include_consolidated=True did nothing on
+        # cluster while working embedded. Forward both; a server that
+        # ignores unknown body fields behaves exactly as before, one that
+        # honors them now honors the caller.
+        body["include_consolidated"] = include_consolidated
+        body["expand_entities"] = expand_entities
         if memory_type:
             body["memory_type"] = memory_type
         if namespace:
@@ -281,12 +295,31 @@ class HttpBackend:
         return self._post("/v1/correct", body)
 
     def think(self, config=None) -> "ThinkResult":
+        # The config arrives as a plain DICT from tools.py. The old code did
+        # getattr() on it — which never finds dict keys — AND looked up
+        # "run_conflicts"/"run_patterns" where the dict carries
+        # "run_conflict_scan"/"run_pattern_mining". Net effect: EVERY
+        # restraint flag a caller passed was silently discarded and a
+        # cluster think() always ran full consolidation. Same incident shape
+        # as the maintenance dry_run: the caller's restraint dropped at a
+        # boundary that swallowed the difference.
         body = {}
         if config:
-            body["run_consolidation"] = getattr(config, "run_consolidation", True)
-            body["run_conflicts"] = getattr(config, "run_conflicts", True)
-            body["run_patterns"] = getattr(config, "run_patterns", True)
-            body["run_personality"] = getattr(config, "run_personality", True)
+            get = config.get if isinstance(config, dict) else (
+                lambda k, d=None: getattr(config, k, d))
+            for dict_key, wire_key in [
+                ("run_consolidation", "run_consolidation"),
+                ("run_conflict_scan", "run_conflicts"),
+                ("run_pattern_mining", "run_patterns"),
+                ("run_personality", "run_personality"),
+                ("consolidation_limit", "consolidation_limit"),
+                ("consolidation_time_window_days", "consolidation_time_window_days"),
+                ("min_active_memories", "min_active_memories"),
+                ("max_triggers", "max_triggers"),
+            ]:
+                v = get(dict_key)
+                if v is not None:
+                    body[wire_key] = v
         result = self._post("/v1/think", body)
         return _ThinkResult(result)
 
@@ -384,10 +417,14 @@ class HttpBackend:
         return _Stats(result)
 
     def get(self, rid: str):
-        """Get a single memory by RID — returns None-like if not found."""
-        # The server doesn't have a direct GET-by-RID endpoint;
-        # recall with exact text isn't feasible. Return a stub.
-        return None
+        """Get a single memory by RID."""
+        # Was a stub returning None — every rid then reported "Memory not
+        # found", blaming the rid instead of the backend, and
+        # update_importance (which pre-reads) failed with the same lie.
+        raise RemoteUnsupportedError(
+            "get-by-rid is not exposed by the HTTP API yet; this is a "
+            "backend limitation, not a missing memory."
+        )
 
     def get_beliefs_above(self, min_confidence: float) -> list:
         return []
@@ -397,15 +434,33 @@ class HttpBackend:
 
     def recall_feedback(self, *, rid, feedback, query_text=None,
                         score_at_retrieval=None, rank_at_retrieval=None):
-        pass  # Not exposed via HTTP API yet
+        # Was `pass` — tools.py then reported {"status": "recorded"}: a
+        # false receipt for a write into the void, and the retrieval-tuning
+        # loop silently never learned on cluster. Absent beats
+        # advertised-but-inert (agreement #6).
+        raise RemoteUnsupportedError(
+            "recall_feedback is not exposed by the HTTP API yet; feedback "
+            "was NOT recorded. Run against an embedded engine to tune "
+            "retrieval, or upgrade the server when the endpoint ships."
+        )
 
     def recall_refine(self, *, original_query_embedding, refinement_text,
                       original_rids, top_k, namespace=None, domain=None, source=None):
-        # Fall back to regular recall
-        return self.recall_with_response(
-            query=refinement_text, top_k=top_k,
+        # Degraded refine: no server endpoint yet, so this is a plain recall
+        # — but the ONE thing refine promises its caller is "not the hits I
+        # just rejected", and the old fallback returned exactly those. Over-
+        # fetch and filter the excluded rids client-side; the embedding-space
+        # refinement math stays unavailable until the endpoint ships.
+        excluded = set(original_rids or [])
+        result = self.recall_with_response(
+            query=refinement_text, top_k=top_k + len(excluded),
             namespace=namespace, domain=domain, source=source,
         )
+        if excluded and isinstance(result, dict):
+            kept = [r for r in result.get("results", [])
+                    if r.get("rid") not in excluded]
+            result["results"] = kept[:top_k]
+        return result
 
     def embed(self, text: str):
         return None  # Not needed for HTTP backend recall_refine fallback

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -314,9 +314,36 @@ def remember(
             elif created_at_ts is not None:
                 inputs[-1]["created_at"] = created_at_ts
 
-        # Prefer record_batch (v0.9.0+) for atomic batch insert; fall back to
-        # loop on older engines OR HTTP backend that may not expose it.
-        if hasattr(db, "record_batch"):
+        # A KEYED batch must not take the record_batch happy path: the
+        # engine requires caller-supplied embeddings for keyed batch items
+        # (the digest includes the vector), and the old code silently
+        # dropped the keys here — so the documented "{key}:{index}"
+        # exactly-once contract held ONLY on the fallback loop, and a
+        # retried batch double-wrote every item on the common path. The
+        # per-item loop below (engine-embedded keyed writes) IS the
+        # correct keyed path.
+        #
+        # Same rule for per-item created_at on backends whose record()
+        # cannot honor it: single-mode refuses loudly (the v0.14 guard);
+        # letting batch items slip through would stamp "now" on backfilled
+        # history — precisely the corruption that guard exists to refuse.
+        import inspect as _inspect
+
+        try:
+            _rec_takes_created_at = (
+                "created_at" in _inspect.signature(db.record).parameters
+            )
+        except (ValueError, TypeError):
+            _rec_takes_created_at = False
+        batch_has_created_at = any(m.get("created_at") is not None for m in inputs)
+        if batch_has_created_at and not _rec_takes_created_at:
+            raise ToolError(
+                "memories[].created_at requires an engine/backend whose "
+                "record() accepts created_at (engine >= 0.14 embedded); "
+                "this backend would silently stamp 'now' on backfilled "
+                "history. Remove per-item created_at or upgrade."
+            )
+        if hasattr(db, "record_batch") and not idempotency_key:
             try:
                 results = db.record_batch(inputs)
                 if isinstance(results, list):
@@ -714,7 +741,7 @@ def think(
     consolidation_limit: int = 5,
     maintenance_cycle: bool = False,
     last_cycle_only: bool = False,
-    dry_run: bool = True,
+    dry_run: bool | None = None,
     burn_down_conflicts: bool = True,
     prune_triggers_too: bool = True,
     max_pending_triggers: int = 64,
@@ -787,6 +814,22 @@ def think(
         return json.dumps({"last_maintenance_cycle": last})
 
     # Full v0.9.0 maintenance cycle
+    # dry_run semantics after the 2026-08-15 incident: None (the default)
+    # means "preview" for the maintenance cycle — the safe default — and is
+    # simply absent for incremental think, which has no dry form. An
+    # EXPLICIT dry_run=True on an incremental think is a caller who believes
+    # they are previewing a pass that would actually mutate (consolidation
+    # merges, conflict scan writes rows): refuse loudly, never run wet
+    # under a preview-shaped call.
+    if dry_run is True and not maintenance_cycle and not last_cycle_only and not maintenance_op:
+        raise ToolError(
+            "dry_run applies only to maintenance_cycle=True. A plain think() "
+            "pass has no dry form (consolidation and conflict scanning both "
+            "write). Call think(maintenance_cycle=True, dry_run=True) for a "
+            "preview, or omit dry_run to acknowledge the mutation."
+        )
+    effective_dry = True if dry_run is None else dry_run
+
     if maintenance_cycle:
         result = db.run_maintenance_cycle(
             run_think=run_consolidation,
@@ -800,6 +843,15 @@ def think(
             split_oversized=split_oversized,
             split_min_chars=split_min_chars,
             repair_artifacts=repair_artifacts,
+            # THE 2026-08-15 INCIDENT LINE. This parameter was accepted,
+            # documented ("preview without persisting"), defaulted True — and
+            # never passed. A "dry" call auto-resolved 15 conflicts and
+            # tombstoned 13 live records on the production store (restored
+            # same day, metadata.restored_from). Requires engine >= the build
+            # carrying MaintenanceCycleConfig.dry_run; older engines raise
+            # TypeError here rather than silently running wet, which is the
+            # correct failure.
+            dry_run=effective_dry,
         )
         return json.dumps({"maintenance_cycle": result if isinstance(result, dict) else {"result": result}})
 
@@ -1027,7 +1079,7 @@ def graph(
     # v0.9.0: record-to-record link primitives + auto_relate
     source_rid: str | None = None,
     target_rid: str | None = None,
-    link_type: str = "related_to",
+    link_type: str | None = None,
     direction: str = "both",
     dry_run: bool = True,
     max_edges: int = 500,
@@ -1125,16 +1177,19 @@ def graph(
     if action == "record_link":
         if not source_rid or not target_rid:
             raise ToolError("source_rid and target_rid required for record_link")
-        link_id = db.link(source_rid, target_rid, link_type)
+        # Creation keeps its default; None here means "unspecified", which
+        # for a CREATE is related_to (the old param-level default).
+        eff_link_type = link_type or "related_to"
+        link_id = db.link(source_rid, target_rid, eff_link_type)
         return json.dumps({
             "link_id": link_id, "source_rid": source_rid,
-            "target_rid": target_rid, "link_type": link_type,
+            "target_rid": target_rid, "link_type": eff_link_type,
         })
 
     if action == "record_unlink":
         if not source_rid or not target_rid:
             raise ToolError("source_rid and target_rid required for record_unlink")
-        removed = db.unlink(source_rid, target_rid, link_type)
+        removed = db.unlink(source_rid, target_rid, link_type or "related_to")
         return json.dumps({"removed": removed})
 
     if action == "linked_records":
@@ -1142,7 +1197,11 @@ def graph(
             raise ToolError("rid required for linked_records")
         if direction not in ("outbound", "inbound", "both"):
             raise ToolError("direction must be 'outbound', 'inbound', or 'both'")
-        rows = db.linked_records(rid, direction=direction, link_type=(link_type if link_type != "related_to" else None))
+        # Filter semantics fixed: None = all types; an EXPLICIT value —
+        # including "related_to", the most common type and previously
+        # indistinguishable from the default and silently unfiltered —
+        # now actually filters.
+        rows = db.linked_records(rid, direction=direction, link_type=link_type)
         return json.dumps({"rid": rid, "direction": direction, "count": len(rows or []), "linked": rows or []})
 
     if action == "recall_with_links":
@@ -1293,6 +1352,12 @@ def trigger(
 
     if action == "pending":
         trigger_list = db.get_pending_triggers(limit=limit)
+        # The docstring promises trigger_type filters pending too (history
+        # already passes it); pending silently ignored it. Filter here —
+        # client-side, so older engines behave identically.
+        if trigger_type:
+            trigger_list = [t for t in trigger_list
+                            if t.get("trigger_type") == trigger_type]
         items = [
             {"trigger_id": t["trigger_id"], "trigger_type": t["trigger_type"],
              "urgency": t.get("urgency"), "reason": t.get("reason"),
@@ -1875,7 +1940,7 @@ def skill(
     action: str,
     skill_id: str | None = None,
     body: str | None = None,
-    skill_type: str = "procedure",
+    skill_type: str | None = None,
     applies_to: list[str] | None = None,
     triggers: list[str] | None = None,
     on_conflict: str = "reject",
@@ -2018,6 +2083,11 @@ def skill(
         # namespace, then content scanning (A1-A5), then B4 supersedes,
         # then existence/conflict (which requires DB I/O).
         try:
+            # Define keeps its old default; None means "unspecified", which
+            # for a DEFINE is procedure. The param-level default previously
+            # leaked into surface/list, where an EXPLICIT procedure filter
+            # was indistinguishable from the default and silently disabled.
+            skill_type = skill_type or "procedure"
             validate_skill_define_args(skill_id or "", body or "", skill_type, applies_to)
         except ValueError as e:
             COUNTERS.reject_define("schema")
@@ -2183,7 +2253,7 @@ def skill(
             raise ToolError("query required for action='surface'")
         if applies_to is not None and not isinstance(applies_to, list):
             raise ToolError("applies_to must be a list")
-        if skill_type and skill_type != "procedure" and skill_type not in SKILL_TYPES:
+        if skill_type and skill_type not in SKILL_TYPES:
             raise ToolError(f"skill_type {skill_type!r} not in {sorted(SKILL_TYPES)}")
 
         # Reads only see the LIVE catalog, never the pending-review queue.
@@ -2217,7 +2287,7 @@ def skill(
                 skill_applies = set(meta.get("applies_to") or [])
                 if not (set(applies_to) & skill_applies):
                     continue
-            if skill_type and skill_type != "procedure":
+            if skill_type:
                 if meta.get("skill_type") != skill_type:
                     continue
             items.append({
@@ -2365,7 +2435,7 @@ def skill(
                 skill_applies = set(meta.get("applies_to") or [])
                 if not (set(applies_to) & skill_applies):
                     continue
-            if skill_type and skill_type != "procedure":
+            if skill_type:
                 if meta.get("skill_type") != skill_type:
                     continue
             items.append({
@@ -2477,7 +2547,7 @@ def task(
     action: str,
     namespace: str = "default",
     title: str | None = None,
-    priority: str = "medium",
+    priority: str | None = None,
     parent_id: str | None = None,
     task_id: str | None = None,
     status: str | None = None,
@@ -2515,8 +2585,13 @@ def task(
     if action == "add":
         if not title or not title.strip():
             raise ToolError("title required for action='add'")
-        tid = db.task_add(namespace, title.strip(), priority=priority, parent_id=parent_id)
-        return json.dumps({"task_id": tid, "title": title.strip(), "priority": priority})
+        # priority defaults at the ADD site now. The old param-level
+        # default "medium" leaked into action="update": updating only
+        # status silently RESET a high/low task to medium — a field the
+        # caller never passed, mutated.
+        eff_priority = priority or "medium"
+        tid = db.task_add(namespace, title.strip(), priority=eff_priority, parent_id=parent_id)
+        return json.dumps({"task_id": tid, "title": title.strip(), "priority": eff_priority})
 
     if action == "get":
         if not task_id:

--- a/tests/test_tool_profiles_and_budget.py
+++ b/tests/test_tool_profiles_and_budget.py
@@ -73,7 +73,13 @@ FULL_TOOLS = CORE_TOOLS | {
 #     diff that looked fine locally (exactly what happened here).
 #     Follow-up worth doing: measure per-interpreter rather than assuming one
 #     number fits all, so this ceiling stops drifting with the Python matrix.
-SCHEMA_BUDGET_CHARS = 46_800
+#
+# (3) v0.18.0 lands at 46,812 on py3.10/3.12 (over by 12): the chars are the
+#     honest-refusal descriptions on get-by-rid and recall_feedback — the
+#     tools that previously returned "Memory not found" / a false "recorded"
+#     receipt for backend gaps. A description that stops an agent from
+#     retrying a rid that was never the problem earns its 12 chars.
+SCHEMA_BUDGET_CHARS = 46_900
 
 
 def _rpc(proc, method, params, mid):

--- a/tests/test_v011_engine_contract_cases.py
+++ b/tests/test_v011_engine_contract_cases.py
@@ -212,5 +212,12 @@ def test_embedder_identity_is_adopted_lazily(eng):
     d.adopt_embedder_identity()
     ident = d.embedder_identity()
     assert set(("name", "digest", "dim")).issubset(ident.keys())
-    assert ident["digest"].startswith("blake3:"), "embedder identity is digest-anchored"
+    # Digest-anchored, algorithm-agnostic: engine 0.14.1 anchored the
+    # bundled embedder with blake3:, the 256-dim default (0.15 line)
+    # anchors with sha256:. Pack seal/mount compares full digest STRINGS,
+    # never prefixes, so pinning the algorithm here tested an
+    # implementation detail and broke on the first legitimate change.
+    algo, _, hexdigest = ident["digest"].partition(":")
+    assert algo and hexdigest, "embedder identity is digest-anchored (algo:hex)"
+    assert all(c in "0123456789abcdef" for c in hexdigest), "digest payload is hex"
     assert isinstance(ident["dim"], int) and ident["dim"] > 0


### PR DESCRIPTION
The 2026-08-15 client-side sweep + the release that carries it.

Every fix is the same defect class — a kwarg accepted at the tool layer that the HTTP backend silently dropped or faked:

- `recall`/`recall_with_response` forward `include_consolidated` and `expand_entities` (accepted and discarded; worked embedded, did nothing on cluster).
- `think()` reads the config dict it is actually given (`getattr` on a dict finds nothing) under the names tools.py actually sends, and forwards the four limit fields. Every restraint flag was previously discarded — a cluster `think()` always ran full consolidation; same incident shape as the maintenance `dry_run`.
- `get`-by-rid and `recall_feedback` raise `RemoteUnsupportedError` instead of lying (`get()` blamed the rid for a backend gap; `recall_feedback` returned a false "recorded" receipt).
- `recall_refine` no longer returns exactly the rids the caller just rejected — over-fetch + client-side filter until the server endpoint ships.
- Engine pin raised to `>=0.15.0,<0.16.0`: `think(dry_run)` forwards to a binding parameter pre-0.15 engines don't have, and the TypeError there is the designed failure (a preview must never silently run wet).
- Contract-test update: embedder identity asserts digest-anchoring without pinning the hash algorithm (0.15's 256-dim default anchors `sha256:` where 0.14.1 used `blake3:`; seal/mount compare full digest strings, never prefixes).

Verified: 266 passed / 3 skipped / 1 xfailed in a fresh venv against the **published** 0.15.0 wheel — including `think(maintenance_cycle, dry_run)` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)