### PR TITLE
feat(tools): time-window retrieval — recall since/until + temporal range

### DIFF
--- a/src/yantrikdb_mcp/http_backend.py
+++ b/src/yantrikdb_mcp/http_backend.py
@@ -19,6 +19,22 @@ import requests
 log = logging.getLogger("yantrikdb.mcp.http")
 
 
+def _within(created_at, window: tuple) -> bool:
+    """True when a row's created_at falls inside [since, until].
+
+    A row with NO created_at fails the window: for a time-window query,
+    "recorded at an unknown time" is not "recorded inside the window", and
+    admitting it would smuggle unfiltered rows past the filter.
+    """
+    if created_at is None:
+        return False
+    try:
+        ts = float(created_at)
+    except (TypeError, ValueError):
+        return False
+    return window[0] <= ts <= window[1]
+
+
 class RemoteUnsupportedError(NotImplementedError):
     """Raised when a method is not yet exposed over the HTTP transport.
 
@@ -188,7 +204,8 @@ class HttpBackend:
     def recall_with_response(self, *, query: str, top_k: int = 10,
                              memory_type=None, include_consolidated=False,
                              expand_entities=True, namespace=None,
-                             domain=None, source=None) -> dict:
+                             domain=None, source=None,
+                             time_window: tuple | None = None) -> dict:
         body: dict = {"query": query, "top_k": top_k}
         # These two were accepted and silently dropped — recall(
         # expand_entities=...) / include_consolidated=True did nothing on
@@ -205,10 +222,21 @@ class HttpBackend:
             body["domain"] = domain
         if source:
             body["source"] = source
+        if time_window:
+            # Forwarded for servers that will honor it; POST-FILTERED below
+            # for those that don't, because a window silently unapplied
+            # returns out-of-window rows as if they were in-window — the
+            # exact failure the parameter exists to fix. Until the server
+            # wires it, cluster callers get reduced in-window depth (the
+            # top_k is relevance-picked before the client filter), never
+            # wrong rows.
+            body["time_window"] = [time_window[0], time_window[1]]
         result = self._post("/v1/recall", body)
         # Adapt server response to match embedded engine format
         items = []
         for r in result.get("results", []):
+            if time_window and not _within(r.get("created_at"), time_window):
+                continue
             items.append({
                 "rid": r.get("rid", ""),
                 "text": r.get("text", ""),
@@ -229,7 +257,8 @@ class HttpBackend:
     def recall(self, *, query: str, top_k: int = 10, memory_type=None,
                include_consolidated=False, expand_entities=True,
                namespace=None, domain=None, source=None,
-               include_superseded: bool = False, **_kw) -> list:
+               include_superseded: bool = False,
+               time_window: tuple | None = None, **_kw) -> list:
         """Row-level recall (embedded `db.recall` parity) — used by the
         tool layer's include_superseded archaeology path. Forwards
         include_superseded to /v1/recall (yantrikdb-server wires the param
@@ -254,9 +283,16 @@ class HttpBackend:
             body["source"] = source
         if include_superseded:
             body["include_superseded"] = True
+        if time_window:
+            # Same forward-plus-post-filter contract as recall_with_response
+            # (see the comment there). This param must NOT fall into **_kw:
+            # a swallowed window returns out-of-window rows as in-window.
+            body["time_window"] = [time_window[0], time_window[1]]
         result = self._post("/v1/recall", body)
         rows = []
         for r in result.get("results", []):
+            if time_window and not _within(r.get("created_at"), time_window):
+                continue
             rows.append({
                 "rid": r.get("rid", ""),
                 "text": r.get("text", ""),

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -448,6 +448,8 @@ def recall(
     include_superseded: bool = False,
     expand_entities: bool = True,
     min_score_ratio: float | None = None,
+    since: str | None = None,
+    until: str | None = None,
     refine_from: str | None = None,
     refine_exclude: list[str] | None = None,
     ctx: Context = None,
@@ -467,6 +469,9 @@ def recall(
     memory(action="feedback", rid=..., feedback="relevant").
     For "what is the CURRENT/latest X", prefer memory(action="chain_head") —
     similarity favors the most-similar revision, not the newest.
+    For "what happened <period>, in what order" ("tonight", "this week")
+    use temporal(action="range") or since/until here — those words name the
+    time frame, not the content; bare similarity cannot see the window.
 
     QUERY: one short natural-language sentence (5-10 words), NOT a keyword
     list — keyword stuffing degrades quality. One focused question per call;
@@ -493,10 +498,36 @@ def recall(
             (0.8 = keep only near-as-good matches). Semantic search always
             returns top_k, even when one result is relevant and the rest are
             noise; this trims the tail instead of making you judge it.
+        since: Only memories from this instant on — "2026-08-01",
+            "2026-08-01T14:30:00Z", "6h"/"7d" (ago), or unix seconds.
+            Filters BEFORE ranking: top_k is chosen inside the window.
+        until: Window end (same formats; default now). Alone = up to then.
         refine_from: Original query text to refine from. query becomes the refinement.
         refine_exclude: Memory IDs to exclude when refining.
     """
     db = _get_db(ctx)
+
+    # Time window, parsed up front so a bad instant fails loudly before any
+    # engine call. The probe that motivated this: recall("in what order did
+    # tonight's releases ship") returned six-month-old records while six
+    # in-window memories written hours earlier scored zero — and passing
+    # since/until to the old schema was SILENTLY DROPPED by validation, the
+    # worst of the three behaviors (honored > rejected > swallowed).
+    time_window: tuple[float, float] | None = None
+    if since is not None or until is not None:
+        ts_since = _parse_timestamp(since, field="since") if since is not None else 0.0
+        ts_until = _parse_timestamp(until, field="until") if until is not None else time.time()
+        if ts_since >= ts_until:
+            raise ToolError(
+                f"empty time window: since ({_iso_utc(ts_since)}) is not before "
+                f"until ({_iso_utc(ts_until)})"
+            )
+        if refine_from:
+            # recall_refine has no time-window path in the engine; advertising
+            # the combination and ignoring half of it would repeat the exact
+            # silent-drop failure this parameter exists to fix.
+            raise ToolError("since/until cannot be combined with refine_from — refine has no time-window support")
+        time_window = (ts_since, ts_until)
 
     # Pre-v0.10 feedback calls used query="" with feedback_rid — that param
     # moved to memory(action="feedback") and schema validation now drops it,
@@ -540,6 +571,7 @@ def recall(
             expand_entities=expand_entities,
             namespace=namespace, domain=domain, source=source,
             include_superseded=True,
+            time_window=time_window,
         )
         response = {
             "results": rows or [],
@@ -551,6 +583,7 @@ def recall(
             query=query, top_k=top_k, memory_type=memory_type,
             include_consolidated=include_consolidated, expand_entities=expand_entities,
             namespace=namespace, domain=domain, source=source,
+            time_window=time_window,
         )
     # Relative score cutoff, applied CLIENT-SIDE on purpose.
     #
@@ -626,6 +659,12 @@ def recall(
         "confidence": round(response["confidence"], 4),
         "hints": hints,
     }
+    if time_window is not None:
+        # Echoed so the caller can SEE the filter was applied — the failure
+        # mode this replaces was a window silently ignored, which is
+        # indistinguishable from a window honored over a dense corpus.
+        out["time_window"] = {"since": _iso_utc(time_window[0]),
+                              "until": _iso_utc(time_window[1])}
     # Say so when the cutoff dropped hits. Otherwise a filtered result reads
     # like "the substrate barely knows this", and the agent's next move is a
     # broader re-query it doesn't need — or a wrong conclusion about coverage.
@@ -1570,29 +1609,121 @@ def temporal(
     namespace: str | None = None,
     query: str | None = None,
     as_of: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
     ctx: Context = None,
 ) -> str:
-    """Find stale or upcoming memories, or recall the past as it was known.
+    """Find stale or upcoming memories, recall the past, or scan a time window.
 
     ACTIONS:
     - "stale": Important memories not accessed recently.
     - "upcoming": Memories with approaching deadlines/events.
     - "as_of": Time-travel recall — excludes anything recorded after `as_of`,
                so you see the belief held then, not today's. Engine v0.12+.
+    - "range": Everything in a time window, oldest first — the surface for
+               "what happened tonight / this week, in what order". Period
+               and sequence questions are SET queries over a window;
+               similarity search cannot answer them — route them here.
 
     Args:
-        action: "stale", "upcoming", or "as_of".
+        action: "stale", "upcoming", "as_of", or "range".
         days: Inactivity threshold (stale) or look-ahead window (upcoming).
         limit: Max results.
         namespace: Optional filter.
-        query: Search text (required for "as_of").
+        query: Search text (required for "as_of"; optional for "range":
+               given = relevance-selected within the window, omitted =
+               the window's newest `limit` records).
         as_of: Past instant (required for "as_of"): "2026-08-01",
                "2026-08-01T14:30:00Z", "7d"/"24h" (ago), or unix seconds.
+        since: Window start (required for "range"), same formats as as_of.
+        until: Window end for "range" — defaults to now.
     """
-    if action not in ("stale", "upcoming", "as_of"):
-        raise ToolError("action must be 'stale', 'upcoming', or 'as_of'")
+    if action not in ("stale", "upcoming", "as_of", "range"):
+        raise ToolError("action must be 'stale', 'upcoming', 'as_of', or 'range'")
 
     db = _get_db(ctx)
+
+    if action == "range":
+        if not since:
+            raise ToolError(
+                'range requires `since` — the window start (e.g. "6h", '
+                '"2026-08-16", "2026-08-16T00:00:00Z", or unix seconds)'
+            )
+        ts_since = _parse_timestamp(since, field="since")
+        ts_until = _parse_timestamp(until, field="until") if until else time.time()
+        if ts_since >= ts_until:
+            raise ToolError(
+                f"empty time window: since ({_iso_utc(ts_since)}) is not before "
+                f"until ({_iso_utc(ts_until)})"
+            )
+        if query and query.strip():
+            # Relevance decides WHICH `limit` records when the window holds
+            # more than fit; the window decides the candidate set; time
+            # decides presentation. All three roles stated in the output.
+            rows = db.recall(
+                query=query, top_k=limit, namespace=namespace,
+                time_window=(ts_since, ts_until),
+            ) or []
+            selection = "relevance-selected within the window"
+        else:
+            # Pure window scan: page the created_at-descending listing and
+            # stop at the first record older than the window. Newest `limit`
+            # kept — for a window smaller than `limit` that is the complete
+            # window.
+            rows, truncated, scan_offset = [], False, 0
+            batch = 200
+            while True:
+                try:
+                    page = db.list_memories(limit=batch, offset=scan_offset,
+                                            namespace=namespace, sort_by="created_at")
+                except NotImplementedError:
+                    # HTTP cluster mode has no listing endpoint yet. Refuse
+                    # with the working alternative rather than half-answer.
+                    raise ToolError(
+                        "range without `query` needs a listing scan, which the "
+                        "HTTP cluster transport does not support yet — pass a "
+                        "`query` (relevance-selected within the window) or run "
+                        "in embedded mode."
+                    )
+                mems = page.get("memories") or []
+                if not mems:
+                    break
+                older_reached = False
+                for m in mems:
+                    ca = float(m.get("created_at") or 0.0)
+                    if ca > ts_until:
+                        continue
+                    if ca < ts_since:
+                        older_reached = True
+                        break
+                    if len(rows) >= limit:
+                        truncated = True
+                        older_reached = True
+                        break
+                    rows.append(m)
+                if older_reached:
+                    break
+                scan_offset += batch
+                if scan_offset >= page.get("total", 0):
+                    break
+            selection = ("newest %d of a larger window — narrow the window or raise limit"
+                         % limit) if truncated else "complete window"
+        rows = sorted(rows, key=lambda m: float(m.get("created_at") or 0.0))
+        return json.dumps({
+            "since": _iso_utc(ts_since),
+            "until": _iso_utc(ts_until),
+            "count": len(rows),
+            "order": "chronological (oldest first)",
+            "selection": selection,
+            "results": [
+                {"rid": m.get("rid"), "text": m.get("text"),
+                 "type": m.get("type"),
+                 "importance": round(float(m.get("importance") or 0.0), _FLOAT_ROUND_PLACES),
+                 "created_at": _iso_utc(m["created_at"]) if m.get("created_at") else None,
+                 "created_at_unix": round(float(m.get("created_at") or 0.0), 3)}
+                for m in rows if isinstance(m, dict)
+            ],
+        })
 
     if action == "as_of":
         if not query or not query.strip():

--- a/tests/test_time_window_range.py
+++ b/tests/test_time_window_range.py
@@ -1,0 +1,172 @@
+"""Time-window retrieval: recall(since/until) + temporal(action="range").
+
+The failure these surfaces fix, reproduced live on the production store
+2026-08-16: recall("in what order did tonight's releases ship") returned
+April/May records keyword-matched on "tonight"/"order"/"release" while six
+release memories written HOURS earlier retrieved ZERO — and passing
+since/until to the old schema was SILENTLY DROPPED by validation. Sequence
+and period questions are SET queries over a time window; similarity search
+structurally cannot answer them because the question's words describe the
+frame, not the content.
+
+The engine has carried `time_window` since before the rename; these tests
+pin the MCP layer actually forwarding it (recall) and the new chronological
+window scan (range). Every filtering test is fail-on-old: on v0.18.0 the
+params did not exist, so the calls TypeError.
+"""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from yantrikdb_mcp._compat import ToolError
+from yantrikdb_mcp.tools import recall, temporal
+
+
+class _Ctx:
+    def __init__(self, db):
+        self.request_context = type("R", (), {"lifespan_context": {"lazy": type("L", (), {"db": db})()}})()
+
+
+@pytest.fixture
+def ctx(tmp_path):
+    import os
+
+    os.environ.setdefault("YANTRIKDB_EMBEDDER", "bundled")
+    from yantrikdb_mcp.embedder import load_engine
+
+    db = load_engine(str(tmp_path / "window.db"), model_name="bundled")
+    yield _Ctx(db)
+    try:
+        db.close()
+    except AttributeError:
+        pass
+
+
+def _seed_ledger(ctx):
+    """Four in-window release events (1h apart) + one 300-day-old decoy that
+    similarity LOVES for release-shaped queries — the live failure shape."""
+    db = ctx.request_context.lifespan_context["lazy"].db
+    now = time.time()
+    events = [
+        ("engine 0.15.0 shipped to PyPI and crates.io", now - 4 * 3600),
+        ("CT128 deployed engine 0.15.0 from the published wheel", now - 3 * 3600),
+        ("mcp 0.18.0 released and dogfooded on CT128", now - 2 * 3600),
+        ("server 0.16.0 released, train complete", now - 1 * 3600),
+    ]
+    for text, at in events:
+        db.record(text, memory_type="episodic", namespace="tw", created_at=at)
+    db.record(
+        "ancient release ledger: every deploy shipped in order tonight after tonight",
+        memory_type="episodic", namespace="tw", created_at=now - 300 * 86400,
+    )
+    return now
+
+
+# ── recall(since/until) ──────────────────────────────────────────────
+
+
+def test_recall_window_excludes_out_of_window_rows(ctx):
+    now = _seed_ledger(ctx)
+    out = json.loads(recall("releases shipped", namespace="tw",
+                            since="6h", ctx=ctx))
+    blob = json.dumps(out["results"])
+    assert "0.15.0" in blob, "in-window rows must be retrievable"
+    assert "ancient release ledger" not in blob, (
+        "a row from 300 days ago must not survive since='6h' — filtering "
+        "after ranking (or not at all) is the failure this param fixes"
+    )
+    # The response must SAY the window was applied; a silently-honored filter
+    # is indistinguishable from a silently-dropped one on a dense corpus.
+    assert "time_window" in out
+    assert out["time_window"]["since"] < out["time_window"]["until"]
+    del now
+
+
+def test_recall_until_alone_means_everything_up_to_then(ctx):
+    _seed_ledger(ctx)
+    out = json.loads(recall("release ledger deploys", namespace="tw",
+                            until="30d", ctx=ctx))
+    blob = json.dumps(out["results"])
+    assert "ancient release ledger" in blob
+    assert "0.15.0" not in blob, "rows newer than `until` must be excluded"
+
+
+def test_recall_rejects_empty_window(ctx):
+    with pytest.raises(ToolError, match="empty time window"):
+        recall("anything", since="1h", until="2h", ctx=ctx)
+
+
+def test_recall_rejects_window_with_refine(ctx):
+    with pytest.raises(ToolError, match="refine"):
+        recall("refined", refine_from="original", since="6h", ctx=ctx)
+
+
+def test_recall_window_survives_include_superseded_path(ctx):
+    """The archaeology path goes through row-level db.recall — the window
+    must ride BOTH paths, not just recall_with_response."""
+    _seed_ledger(ctx)
+    out = json.loads(recall("releases shipped", namespace="tw", since="6h",
+                            include_superseded=True, ctx=ctx))
+    assert "ancient release ledger" not in json.dumps(out["results"])
+
+
+# ── temporal(action="range") ─────────────────────────────────────────
+
+
+def test_range_requires_since(ctx):
+    with pytest.raises(ToolError, match="since"):
+        temporal(action="range", ctx=ctx)
+
+
+def test_range_rejects_empty_window(ctx):
+    with pytest.raises(ToolError, match="empty time window"):
+        temporal(action="range", since="1h", until="2h", ctx=ctx)
+
+
+def test_range_scan_returns_window_chronologically(ctx):
+    """The dogfood gate: 'what happened tonight, in order' answered from the
+    window alone — no query, complete window, oldest first."""
+    _seed_ledger(ctx)
+    out = json.loads(temporal(action="range", since="6h", namespace="tw", ctx=ctx))
+    texts = [r["text"] for r in out["results"]]
+    assert len(texts) == 4, f"expected the complete 4-event window, got {texts}"
+    assert "ancient" not in json.dumps(texts)
+    order = ["engine 0.15.0", "CT128 deployed", "mcp 0.18.0", "server 0.16.0"]
+    for expected, got in zip(order, texts):
+        assert expected in got, (
+            f"chronological order broken: wanted {order}, got {texts}"
+        )
+    assert out["order"].startswith("chronological")
+    assert out["selection"] == "complete window"
+    # created_at emitted in both readable and comparable forms.
+    assert out["results"][0]["created_at"].endswith("Z")
+    assert out["results"][0]["created_at_unix"] < out["results"][1]["created_at_unix"]
+
+
+def test_range_with_query_selects_by_relevance_inside_window(ctx):
+    _seed_ledger(ctx)
+    out = json.loads(temporal(action="range", since="6h", query="CT128 deploy",
+                              namespace="tw", ctx=ctx))
+    blob = json.dumps(out["results"])
+    assert "CT128" in blob
+    assert "ancient" not in blob
+    assert out["selection"] == "relevance-selected within the window"
+    # Presentation stays chronological even under relevance selection.
+    stamps = [r["created_at_unix"] for r in out["results"]]
+    assert stamps == sorted(stamps)
+
+
+def test_range_truncation_is_named_not_silent(ctx):
+    """A window larger than `limit` must SAY it was truncated — 'covered
+    everything' when it did not is the lie the selection field prevents."""
+    _seed_ledger(ctx)
+    out = json.loads(temporal(action="range", since="6h", limit=2,
+                              namespace="tw", ctx=ctx))
+    assert out["count"] == 2
+    assert "newest 2" in out["selection"]
+    # Newest two of the window, still presented oldest-first.
+    texts = [r["text"] for r in out["results"]]
+    assert "mcp 0.18.0" in texts[0] and "server 0.16.0" in texts[1]

--- a/tests/test_tool_profiles_and_budget.py
+++ b/tests/test_tool_profiles_and_budget.py
@@ -79,7 +79,17 @@ FULL_TOOLS = CORE_TOOLS | {
 #     tools that previously returned "Memory not found" / a false "recorded"
 #     receipt for backend gaps. A description that stops an agent from
 #     retrying a rid that was never the problem earns its 12 chars.
-SCHEMA_BUDGET_CHARS = 46_900
+#
+# 46_900 -> 48_600 (REVIEWED): time-window retrieval — recall gains
+#     since/until and temporal gains "range" (+ its since/until). Measured
+#     48,342 on py3.12 after prose trims; the residual is four `str | None`
+#     params (fat anyOf renders on py3.10/3.12) plus the routing sentences.
+#     Those sentences ARE the fix: the live failure was recall answering
+#     "in what order did tonight's releases ship" with six-month-old
+#     keyword matches while six in-window memories retrieved zero — an
+#     agent that is never told period questions route to range/since-until
+#     re-creates that failure on every deictic query it makes.
+SCHEMA_BUDGET_CHARS = 48_600
 
 
 def _rpc(proc, method, params, mid):


### PR DESCRIPTION
## The failure this fixes

Reproduced live on the production store 2026-08-16: `recall("in what order did tonight's releases ship")` returned April/May records keyword-matched on "tonight"/"order"/"release" while six release memories written **hours** earlier at importance 0.85+ retrieved **zero**. Worse: passing `since`/`until` to the old schema was **silently dropped** by validation — the caller could not opt into a window even deliberately.

Root cause (deep-dig, memory rid `01a00d2a`): period/sequence questions are SET queries over a time window, answered today by POINT similarity — the question's words name the *frame* ("tonight", "in what order"), not the content, so similarity lands in the densest cluster. The engine has carried `time_window` since before the rename; no MCP surface ever exposed it.

## What ships

- **`recall(since=, until=)`** — as_of grammar (ISO / `"6h"` / unix), forwarded as `time_window` on BOTH paths (`recall_with_response` + the `include_superseded` archaeology path), echoed in the response so an applied filter is distinguishable from a swallowed one. Refine mode refuses the combination (engine has no windowed refine; advertised-but-inert is the exact failure class this PR fixes).
- **`temporal(action="range")`** — everything in a window, oldest first. With `query`: relevance-selected within the window. Without: paged created_at scan; truncation is NAMED in `selection`, never silent. Tool descriptions carry the routing rule (period words → range) because an agent never told this re-creates the failure on every deictic query.
- **HTTP backend** — `time_window` forwarded in the body for servers that will honor it AND post-filtered client-side so servers that don't can never leak out-of-window rows as in-window; the row-level recall's `**_kw` sink can no longer swallow it.
- **Schema budget 46,900 → 48,600** — measured 48,342 on py3.12 after prose trims; justification block in the budget file.

## Evidence

- 10 new tests in `test_time_window_range.py`: **all 10 fail on v0.18.0** (params did not exist), all pass here.
- Full suite: 275 passed; the one red is the pre-existing `test_recall_as_of_excludes_later_writes` timing flake (passes 3/3 in isolation; this diff does not touch `recall_as_of`).
- Dogfood gate: on the seeded release ledger, `range` answers "what happened tonight, in order" completely and chronologically, with the 300-day-old similarity-bait decoy excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)