### PR TITLE
v0.19.1: surface maintenance debt — the LLM is the only scheduler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.19.0"
+version = "0.19.1"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"

--- a/src/yantrikdb_mcp/http_backend.py
+++ b/src/yantrikdb_mcp/http_backend.py
@@ -843,6 +843,16 @@ class HttpBackend:
             body["domain"] = domain
         return self._post("/v1/session/end", body)
 
+    # ── maintenance_debt: DELIBERATELY ABSENT, not a raising stub ────
+    # The tool layer probes `hasattr(db, "maintenance_debt")` before every
+    # opportunistic debt read (remember/recall/think surfacing) and silently
+    # no-ops when the method is missing — absence IS the graceful-degradation
+    # contract. A RemoteUnsupportedError stub here would pass the hasattr
+    # probe and turn every write into a raise-and-swallow. Future server
+    # endpoint: GET /v1/maintenance/debt — implement it as a real method
+    # (never a fake returning zeros: fabricated "no debt" would suppress
+    # nudges on a cluster that genuinely needs a think pass).
+
     # ── operator/admin surface (MASTER token, server v0.8.27+) ──────
 
     def maintenance_run(self, *, tenant=None, split_oversized=False,

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -189,6 +189,137 @@ def _prune_nulls(d: dict, keys: tuple[str, ...]) -> dict:
 _RECALL_PRUNABLE_NULLS = ("emotional_state",)
 
 
+# ── maintenance-debt surfacing ──
+# In a reactive deployment the calling LLM is the only scheduler there is:
+# nothing else will ever run think(). Waiting to be ASKED about maintenance
+# debt means it is never seen, so the debt is surfaced inside tool responses
+# — the one guaranteed channel. DATA plus a suggestion, no urgency prose:
+# a measured experiment showed authority-flavored header text flips agent
+# behavior sideways; flat facts land, exhortation backfires.
+#
+# Contract: engine `db.maintenance_debt()` -> {writes_since_think: int,
+# last_think_at: float|None, open_conflicts: int, pending_triggers: int}.
+# hasattr-guarded: on an engine (or the HTTP backend) without the method,
+# ALL of this silently no-ops — graceful degradation, no pin bump.
+#
+# Module-level state is per-PROCESS. In stdio mode that is one session per
+# process, exactly the scope we want. In stateless streamable-http mode a
+# process serves per-connection state — a nudge may re-fire once per fresh
+# connection, which is acceptable (the debt is real either way).
+_NUDGE_STATE = {
+    # armed=True: the next threshold crossing surfaces immediately.
+    "armed": True,
+    # over-threshold remembers since the last surfaced nudge.
+    "since_last": 0,
+    # last open_conflicts value surfaced through ANY response (recall delta
+    # or think's post-run debt). Starts at 0 so a quiet store stays quiet;
+    # a transition back TO 0 still surfaces (the agent saw a nonzero).
+    "conflicts_surfaced": 0,
+}
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        log.warning("%s=%r is not an int — using %d", name, raw, default)
+        return default
+
+
+def _maintenance_debt(db) -> dict | None:
+    """Best-effort read of the engine's maintenance-debt counters.
+
+    Returns None when the running engine predates the method (the entire
+    feature then no-ops) or when the probe itself fails — surfacing is
+    opportunistic and must never fail the call it rides on.
+    """
+    if not hasattr(db, "maintenance_debt"):
+        return None
+    try:
+        debt = db.maintenance_debt()
+    except Exception as e:  # noqa: BLE001 — a debt probe must not fail a write
+        log.debug("maintenance_debt() probe failed: %s: %s", type(e).__name__, e)
+        return None
+    return debt if isinstance(debt, dict) else None
+
+
+def _attach_write_debt(db, payload: dict) -> dict:
+    """After a successful remember(): attach a `maintenance` object when
+    write debt has crossed the nudge threshold.
+
+    Rate limit (in-process): surface on the FIRST crossing, then at most
+    every YANTRIKDB_THINK_NUDGE_EVERY subsequent remembers (default 10)
+    while still over threshold. Dropping below threshold — or a completed
+    think() — rearms the first-crossing nudge.
+    """
+    threshold = _int_env("YANTRIKDB_THINK_NUDGE_THRESHOLD", 50)
+    if threshold <= 0:  # 0 disables
+        return payload
+    debt = _maintenance_debt(db)
+    if debt is None:
+        return payload
+    writes = debt.get("writes_since_think")
+    if not isinstance(writes, int) or writes < threshold:
+        # Below threshold: rearm so the next crossing surfaces immediately.
+        _NUDGE_STATE["armed"] = True
+        _NUDGE_STATE["since_last"] = 0
+        return payload
+    if _NUDGE_STATE["armed"]:
+        fire = True
+    else:
+        _NUDGE_STATE["since_last"] += 1
+        fire = _NUDGE_STATE["since_last"] >= max(1, _int_env("YANTRIKDB_THINK_NUDGE_EVERY", 10))
+    if fire:
+        _NUDGE_STATE["armed"] = False
+        _NUDGE_STATE["since_last"] = 0
+        payload["maintenance"] = {
+            "writes_since_think": writes,
+            "last_think_at": debt.get("last_think_at"),
+            "open_conflicts": debt.get("open_conflicts"),
+            "suggest": "think()",
+        }
+    return payload
+
+
+def _attach_conflict_delta(db, payload: dict) -> dict:
+    """Recall metadata: surface `open_conflicts` ONLY when the count differs
+    from the last value this process surfaced (including transitions to 0).
+    Top-level metadata, never per-result, never prose."""
+    debt = _maintenance_debt(db)
+    if debt is None:
+        return payload
+    oc = debt.get("open_conflicts")
+    if isinstance(oc, int) and oc != _NUDGE_STATE["conflicts_surfaced"]:
+        payload["open_conflicts"] = oc
+        _NUDGE_STATE["conflicts_surfaced"] = oc
+    return payload
+
+
+def _refresh_after_think(db, payload: dict) -> dict:
+    """After a completed think/maintenance pass: rearm the write-debt nudge
+    (the pass is the very thing the nudge asks for) and include the POST-run
+    debt so the caller sees the debt actually cleared — a nudge whose effect
+    is never visible teaches the agent that think() does nothing."""
+    _NUDGE_STATE["armed"] = True
+    _NUDGE_STATE["since_last"] = 0
+    debt = _maintenance_debt(db)
+    if debt is not None:
+        payload["maintenance_debt"] = {
+            "writes_since_think": debt.get("writes_since_think"),
+            "last_think_at": debt.get("last_think_at"),
+            "open_conflicts": debt.get("open_conflicts"),
+            "pending_triggers": debt.get("pending_triggers"),
+        }
+        oc = debt.get("open_conflicts")
+        if isinstance(oc, int):
+            # The think response itself just surfaced the count.
+            _NUDGE_STATE["conflicts_surfaced"] = oc
+    return payload
+
+
 # ── 1. remember ──
 
 
@@ -280,7 +411,8 @@ def remember(
         if not summary.strip():
             raise ToolError("summary must be non-empty when provided")
         result = db.draft_memories_from_summary(summary.strip(), namespace=namespace, domain=domain)
-        return json.dumps(result if isinstance(result, dict) else {"drafted": result})
+        return json.dumps(_attach_write_debt(
+            db, result if isinstance(result, dict) else {"drafted": result}))
 
     # Batch mode — uses record_batch() (v0.9.0) under the hood for one-shot insert
     if memories:
@@ -347,7 +479,8 @@ def remember(
             try:
                 results = db.record_batch(inputs)
                 if isinstance(results, list):
-                    return json.dumps({"rids": results, "count": len(results), "status": "recorded"})
+                    return json.dumps(_attach_write_debt(
+                        db, {"rids": results, "count": len(results), "status": "recorded"}))
             except Exception as e:
                 # Fall through to the per-item loop — but never silently:
                 # if record_batch partially wrote before failing, an unkeyed
@@ -389,7 +522,8 @@ def remember(
                         return translated
                 raise
             results.append(rid)
-        return json.dumps({"rids": results, "count": len(results), "status": "recorded"})
+        return json.dumps(_attach_write_debt(
+            db, {"rids": results, "count": len(results), "status": "recorded"}))
 
     # Single mode
     if not text or not text.strip():
@@ -430,7 +564,7 @@ def remember(
             if translated is not None:
                 return translated
         raise
-    return json.dumps({"rid": rid, "status": "recorded"})
+    return json.dumps(_attach_write_debt(db, {"rid": rid, "status": "recorded"}))
 
 
 # ── 2. recall ──
@@ -558,7 +692,9 @@ def recall(
             {"hint_type": h["hint_type"], "suggestion": h["suggestion"], "related_entities": h["related_entities"]}
             for h in response["hints"]
         ]
-        return json.dumps({"count": len(items), "results": items, "confidence": round(response["confidence"], 4), "hints": hints})
+        return json.dumps(_attach_conflict_delta(db, {
+            "count": len(items), "results": items,
+            "confidence": round(response["confidence"], 4), "hints": hints}))
 
     # Search mode (default)
     if include_superseded:
@@ -670,7 +806,7 @@ def recall(
     # broader re-query it doesn't need — or a wrong conclusion about coverage.
     if filtered_by_ratio:
         out["filtered_by_min_score_ratio"] = filtered_by_ratio
-    return json.dumps(out)
+    return json.dumps(_attach_conflict_delta(db, out))
 
 
 # ── 3. forget ──
@@ -892,7 +1028,8 @@ def think(
             # correct failure.
             dry_run=effective_dry,
         )
-        return json.dumps({"maintenance_cycle": result if isinstance(result, dict) else {"result": result}})
+        return json.dumps(_refresh_after_think(
+            db, {"maintenance_cycle": result if isinstance(result, dict) else {"result": result}}))
 
     # Default incremental think()
     config = {
@@ -911,7 +1048,7 @@ def think(
          "urgency": t["urgency"], "suggested_action": t["suggested_action"]}
         for t in result["triggers"]
     ]
-    return json.dumps({
+    return json.dumps(_refresh_after_think(db, {
         "triggers": triggers,
         "consolidation_count": result["consolidation_count"],
         "conflicts_found": result["conflicts_found"],
@@ -920,7 +1057,7 @@ def think(
         "expired_triggers": result["expired_triggers"],
         "duration_ms": round(result["duration_ms"], 2),
         "patterns": pattern_list[:5] if pattern_list else [],
-    })
+    }))
 
 
 # ── 6. memory ──

--- a/tests/test_backend_parity.py
+++ b/tests/test_backend_parity.py
@@ -83,6 +83,19 @@ def _extract_db_method_calls(tools_src: str) -> set[str]:
     return methods
 
 
+# Methods tools.py invokes ONLY behind a `hasattr(db, ...)` probe, where
+# ABSENCE is the graceful-degradation contract (the caller no-ops, it never
+# AttributeErrors). Defining these on HttpBackend — even as a
+# RemoteUnsupportedError stub — would pass the hasattr probe and defeat the
+# degradation. Each entry must name the guard site.
+HASATTR_GUARDED = {
+    # tools._maintenance_debt(): opportunistic debt read for the
+    # remember/recall/think surfacing; no /v1 endpoint yet (future:
+    # GET /v1/maintenance/debt). See the comment block in http_backend.py.
+    "maintenance_debt",
+}
+
+
 def test_http_backend_covers_every_tools_method() -> None:
     """v0.5.0 regression class — `tools.py` called `db.get_conflict()`
     but HttpBackend didn't define it, so users hit raw AttributeError."""
@@ -90,6 +103,7 @@ def test_http_backend_covers_every_tools_method() -> None:
     HttpBackend = hb.HttpBackend  # noqa: N806
 
     expected = _extract_db_method_calls(TOOLS_PATH.read_text(encoding="utf-8"))
+    expected -= HASATTR_GUARDED
     actual = {
         n for n in dir(HttpBackend)
         if not n.startswith("_") and callable(getattr(HttpBackend, n))
@@ -101,6 +115,16 @@ def test_http_backend_covers_every_tools_method() -> None:
         f"calls on the db object — users in remote-cluster mode would "
         f"hit AttributeError. Add real impls or RemoteUnsupportedError "
         f"stubs for: {sorted(missing)}"
+    )
+
+    # Keep the exemption list honest: the moment one of these lands on
+    # HttpBackend for real (endpoint shipped), it must leave HASATTR_GUARDED
+    # so the parity gate covers it again.
+    stale_exemptions = HASATTR_GUARDED & actual
+    assert not stale_exemptions, (
+        f"{sorted(stale_exemptions)} are defined on HttpBackend but still "
+        f"listed in HASATTR_GUARDED — remove them from the exemption list "
+        f"(and note: a raising stub here would defeat the hasattr no-op)."
     )
 
 

--- a/tests/test_maintenance_debt_surfacing.py
+++ b/tests/test_maintenance_debt_surfacing.py
@@ -1,0 +1,236 @@
+"""Maintenance-debt surfacing — the debt rides IN tool responses.
+
+In a reactive deployment the calling LLM is the only scheduler: nothing else
+will ever run think(). So write debt is surfaced inside remember/recall/think
+responses — flat data plus a suggestion, no urgency prose — against the
+engine contract `db.maintenance_debt()` -> {writes_since_think, last_think_at,
+open_conflicts, pending_triggers}. On an engine WITHOUT the method (the
+published 0.15.x line, and the HTTP backend) every part of this silently
+no-ops; that degradation is itself a contract and is tested here.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from yantrikdb_mcp import tools
+from yantrikdb_mcp.tools import recall, remember, think
+
+
+class _Ctx:
+    def __init__(self, db):
+        self.request_context = type(
+            "R", (), {"lifespan_context": {"lazy": type("L", (), {"db": db})()}}
+        )()
+
+
+class LegacyEngine:
+    """Minimal engine exposing exactly what the surfacing paths touch —
+    WITHOUT maintenance_debt (the published 0.15.x shape). This is the base
+    on purpose: the degradation contract is 'the method is truly absent',
+    not 'the method is overridden'."""
+
+    def __init__(self, writes=0, last_think_at=None, open_conflicts=0,
+                 pending_triggers=0):
+        self.debt = {
+            "writes_since_think": writes,
+            "last_think_at": last_think_at,
+            "open_conflicts": open_conflicts,
+            "pending_triggers": pending_triggers,
+        }
+        self.recorded = 0
+        self.debt_probes = 0
+
+    def record(self, text, **kw):
+        self.recorded += 1
+        return f"rid-{self.recorded}"
+
+    def recall_with_response(self, **kw):
+        return {"results": [], "confidence": 0.0, "hints": []}
+
+    def think(self, config):
+        # A think pass clears write debt on the real engine; mirror that so
+        # the post-run payload shows the debt actually cleared.
+        self.debt["writes_since_think"] = 0
+        return {"triggers": [], "consolidation_count": 0, "conflicts_found": 0,
+                "patterns_new": 0, "patterns_updated": 0, "expired_triggers": 0,
+                "duration_ms": 1.0}
+
+    def get_patterns(self, **kw):
+        return []
+
+
+class FakeEngine(LegacyEngine):
+    """LegacyEngine + the v0.16 maintenance_debt contract."""
+
+    def maintenance_debt(self):
+        self.debt_probes += 1
+        return dict(self.debt)
+
+
+class BrokenDebtEngine(FakeEngine):
+    """Has the method, but it blows up — the probe must never fail a call."""
+
+    def maintenance_debt(self):
+        raise RuntimeError("debt counters unavailable")
+
+
+@pytest.fixture(autouse=True)
+def fresh_state(monkeypatch):
+    """Per-test in-process state + deterministic env."""
+    monkeypatch.setattr(tools, "_NUDGE_STATE",
+                        {"armed": True, "since_last": 0, "conflicts_surfaced": 0})
+    monkeypatch.delenv("YANTRIKDB_THINK_NUDGE_THRESHOLD", raising=False)
+    monkeypatch.delenv("YANTRIKDB_THINK_NUDGE_EVERY", raising=False)
+
+
+def _remember(db, text="fact"):
+    return json.loads(remember(text=text, ctx=_Ctx(db)))
+
+
+def _recall(db):
+    return json.loads(recall(query="anything at all", ctx=_Ctx(db)))
+
+
+# ── remember(): threshold crossing ───────────────────────────────────
+
+
+def test_crossing_threshold_attaches_maintenance_object():
+    db = FakeEngine(writes=50, last_think_at=1755000000.0, open_conflicts=2)
+    out = _remember(db)
+    assert out["status"] == "recorded", "surfacing must not disturb the write receipt"
+    m = out["maintenance"]
+    assert m == {"writes_since_think": 50, "last_think_at": 1755000000.0,
+                 "open_conflicts": 2, "suggest": "think()"}, (
+        "flat facts + suggestion only — no prose fields"
+    )
+
+
+def test_below_threshold_attaches_nothing():
+    db = FakeEngine(writes=49)
+    out = _remember(db)
+    assert "maintenance" not in out
+
+
+def test_threshold_env_is_honored(monkeypatch):
+    monkeypatch.setenv("YANTRIKDB_THINK_NUDGE_THRESHOLD", "5")
+    assert "maintenance" in _remember(FakeEngine(writes=5))
+    tools._NUDGE_STATE.update(armed=True, since_last=0)
+    assert "maintenance" not in _remember(FakeEngine(writes=4))
+
+
+def test_threshold_zero_disables_and_skips_the_probe(monkeypatch):
+    monkeypatch.setenv("YANTRIKDB_THINK_NUDGE_THRESHOLD", "0")
+    db = FakeEngine(writes=10_000)
+    out = _remember(db)
+    assert "maintenance" not in out
+    assert db.debt_probes == 0, "0 disables the feature, not just the payload"
+
+
+def test_batch_write_surfaces_too():
+    db = FakeEngine(writes=50)
+    out = json.loads(remember(memories=[{"text": "a"}, {"text": "b"}], ctx=_Ctx(db)))
+    assert out["count"] == 2
+    assert out["maintenance"]["suggest"] == "think()"
+
+
+# ── remember(): in-process rate limit ────────────────────────────────
+
+
+def test_rate_limit_suppresses_then_refires_at_the_nth(monkeypatch):
+    monkeypatch.setenv("YANTRIKDB_THINK_NUDGE_EVERY", "3")
+    db = FakeEngine(writes=50)
+    assert "maintenance" in _remember(db), "first crossing surfaces"
+    db.debt["writes_since_think"] = 51
+    assert "maintenance" not in _remember(db), "suppressed (1 of 3)"
+    db.debt["writes_since_think"] = 52
+    assert "maintenance" not in _remember(db), "suppressed (2 of 3)"
+    db.debt["writes_since_think"] = 53
+    out = _remember(db)
+    assert out["maintenance"]["writes_since_think"] == 53, "re-fires on the 3rd"
+    db.debt["writes_since_think"] = 54
+    assert "maintenance" not in _remember(db), "counter reset after re-fire"
+
+
+def test_dropping_below_threshold_rearms_the_first_crossing():
+    db = FakeEngine(writes=50)
+    assert "maintenance" in _remember(db)
+    db.debt["writes_since_think"] = 3          # debt cleared out-of-band
+    assert "maintenance" not in _remember(db)
+    db.debt["writes_since_think"] = 50         # crosses again
+    assert "maintenance" in _remember(db), (
+        "a fresh crossing is a FIRST crossing — no 10-call wait"
+    )
+
+
+# ── degradation contract ─────────────────────────────────────────────
+
+
+def test_engine_without_maintenance_debt_no_object_no_error():
+    db = LegacyEngine(writes=999)
+    out = _remember(db)
+    assert out == {"rid": "rid-1", "status": "recorded"}
+    r = _recall(db)
+    assert "open_conflicts" not in r
+    t = json.loads(think(ctx=_Ctx(db)))
+    assert "maintenance_debt" not in t
+
+
+def test_probe_failure_never_fails_the_write():
+    out = _remember(BrokenDebtEngine(writes=999))
+    assert out["status"] == "recorded"
+    assert "maintenance" not in out
+
+
+# ── recall(): open_conflicts changed-since-last-surfaced ─────────────
+
+
+def test_recall_surfaces_open_conflicts_only_on_change():
+    db = FakeEngine(open_conflicts=3)
+    assert _recall(db)["open_conflicts"] == 3, "changed from initial 0 — surface"
+    assert "open_conflicts" not in _recall(db), "unchanged — silent"
+    db.debt["open_conflicts"] = 0
+    assert _recall(db)["open_conflicts"] == 0, "transition TO 0 must surface"
+    assert "open_conflicts" not in _recall(db), "steady 0 — silent again"
+
+
+def test_recall_on_a_quiet_store_stays_quiet():
+    db = FakeEngine(open_conflicts=0)
+    assert "open_conflicts" not in _recall(db), (
+        "0 at process start was never 'surfaced' — nothing changed"
+    )
+
+
+# ── think(): post-run debt + rearm ───────────────────────────────────
+
+
+def test_think_reports_post_run_debt():
+    db = FakeEngine(writes=60, open_conflicts=1, pending_triggers=4)
+    out = json.loads(think(ctx=_Ctx(db)))
+    assert out["maintenance_debt"] == {
+        "writes_since_think": 0,       # POST-run: the debt visibly cleared
+        "last_think_at": None,
+        "open_conflicts": 1,
+        "pending_triggers": 4,
+    }
+
+
+def test_think_rearms_the_nudge():
+    db = FakeEngine(writes=50)
+    assert "maintenance" in _remember(db)      # nudge consumed
+    db.debt["writes_since_think"] = 51
+    assert "maintenance" not in _remember(db)  # rate-limited
+    json.loads(think(ctx=_Ctx(db)))            # pass completes, debt clears
+    db.debt["writes_since_think"] = 50         # ...and builds up again
+    assert "maintenance" in _remember(db), (
+        "post-think crossing must surface immediately, not after N calls"
+    )
+
+
+def test_think_counts_as_surfacing_open_conflicts():
+    db = FakeEngine(open_conflicts=2)
+    json.loads(think(ctx=_Ctx(db)))            # response carried the count
+    assert "open_conflicts" not in _recall(db), (
+        "recall must not re-surface a count think() already reported"
+    )


### PR DESCRIPTION
The reactive-deployment half of the maintenance-cadence design (engine 0.15.2 carries the ledger; the server owns a real timer — RFC 027).

The core is a passive library: it cannot schedule maintenance, and in core+MCP deployments the calling LLM is the only scheduler there is. Standing instructions decay (the documented training-drift failure mode), so the reminder must ride the one channel that cannot be missed — the tool response itself:

- **remember()**: when `writes_since_think` crosses `YANTRIKDB_THINK_NUDGE_THRESHOLD` (default 50, `0` disables), the response carries a flat `maintenance` object — counts plus `suggest: "think()"`, no urgency prose (measured: authority-flavored header text flips agent behavior). Rate-limited: first crossing, then every `YANTRIKDB_THINK_NUDGE_EVERY` (default 10) while still over; rearms on clear.
- **recall**: top-level `open_conflicts` only when the count changed since last surfaced (including transitions to 0). Never per-result.
- **think()**: reports post-run debt so the LLM sees the ledger actually cleared; rearms the nudge.
- Engines without `maintenance_debt()` (≤0.15.1): every part no-ops via a hasattr guard — pin unchanged, proven by running the full suite against the published 0.15.1 (290 passed on the degradation path) and again against the 0.15.2 wheel (290 passed on the live path).
- HttpBackend: deliberately does NOT stub the method — the repo's RemoteUnsupportedError convention would defeat the hasattr guard and turn every write into raise-and-swallow. Comment names the future `GET /v1/maintenance/debt`.
- The static backend-parity gate gains a self-policing exemption: if the method ever lands on HttpBackend, the stale exemption itself fails the gate.

E2E through the real server + real engine: nudge fires at exactly write N, think clears and stamps, post-clear writes are quiet. 14 new tests, all fail-on-old; zero tool-schema growth (budget gate untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)