### PR TITLE
deps: require engine >=0.15.3 — retrieval correctness, not a feature (v0.19.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.19.1"
+version = "0.19.2"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"
@@ -123,7 +123,7 @@ dependencies = [
     # records on the production store). The recall/think field forwarding
     # in this release likewise lands on an engine that actually reads the
     # fields. 266 passed against the published 0.15.0 wheel.
-    "yantrikdb>=0.15.0,<0.16.0",
+    "yantrikdb>=0.15.3,<0.16.0",
     # D3 firewall, same rule as the engine pin above — and for the same
     # reason, learned the same way. `mcp[cli]>=1.2.0` was UNBOUNDED, so the
     # day the SDK shipped 2.0.0 it removed `mcp.server.fastmcp` and every


### PR DESCRIPTION
The ceiling already admitted 0.15.3. The **floor** is the claim that matters: engine 0.15.0–0.15.2 carry three ranking defects and four cutover races, so a floor that still admits them is a floor we know is wrong.

## Ranking — what an MCP memory server actually feels

- **Currency** — freshness was computed from `last_access`, which the engine's `reinforce()` mutates on every recall that *returns* a record. Ranking depended on who had read a record rather than on the record. Measured: one unrelated recall demoted a correct answer from #1 to #3 — for this package that means **the answer moves because the assistant asked something else**.
- **Valence** — applied outside the policy budget and never range-checked; `valence=100` took a 31× multiplier.
- **Cold lane** — admitted only `access_count = 0` rows while `reinforce()` increments exactly that, so the rescue lane self-disabled with use: five ordinary queries drained 53% of the eligible set.

Also restored upstream: the additive keyword boost, whose brief deletion cost **0.336 MRR at 64 dims and 0.217 at 384** on a 5,218-record clone of a real production memory server. Every recall this package serves gets that back.

## Cutover

Four mutators could cross a re-embed cutover, including forget (resurrection) and both replication arms. `embedding_model` provenance is now promoted on Swap instead of staying NULL.

## Schema v41 — operator-visible

Lazy on first open. `decay` changed meaning, so the learned fit against the old meaning is voided and `ranking_feature_epoch` is stamped. A server with a tuned learner re-fits from scratch — expected and correct.

## Gates

`290 passed, 3 skipped, 1 xfailed` against engine 0.15.3, resolved and verified in a clean venv.

## Flagged, not fixed here

`server.json` still advertises **0.14.0** to the MCP registry — five minors behind — and no release commit has touched it since the registry publish landed. Real drift bug, wrong subject for a dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)