### PR TITLE
deps: admit engine 0.16.x and 0.17.x (<0.18.0); tests: probe the installed mcp major

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ dependencies = [
     # that still admits an AGPL engine makes "permissively licensed end to end"
     # true only by luck of resolution order. 0.15.4 is behavior-identical to
     # 0.15.3 — the relicense carried no code change.
-    "yantrikdb>=0.15.4,<0.16.0",
+    "yantrikdb>=0.15.4,<0.18.0",
     # D3 firewall, same rule as the engine pin above — and for the same
     # reason, learned the same way. `mcp[cli]>=1.2.0` was UNBOUNDED, so the
     # day the SDK shipped 2.0.0 it removed `mcp.server.fastmcp` and every

--- a/src/yantrikdb_mcp/_compat.py
+++ b/src/yantrikdb_mcp/_compat.py
@@ -2,7 +2,9 @@
 
 WHY THIS EXISTS
 ---------------
-mcp 2.0.0 removed `mcp.server.fastmcp`. Every symbol this package imports at
+mcp 2.0.0 removed `mcp.server.fastmcp` (2.1.x ships it again alongside the
+canonical `mcp.server.mcpserver`, so its presence is no longer a line
+discriminator — the shim imports the canonical 2.x names first). Every symbol this package imports at
 module scope moved, so `import yantrikdb_mcp` raised ModuleNotFoundError on
 the new SDK — and because the dependency was pinned `>=1.2.0` with no
 ceiling, already-published releases silently re-shipped themselves broken the

--- a/tests/test_mcp_compat.py
+++ b/tests/test_mcp_compat.py
@@ -5,9 +5,20 @@ is worse than no shim: every downstream symbol would still resolve, and the
 mismatch would only surface as strange runtime behaviour on one of the two
 lines. So these tests cross-check the shim's verdict against an independent
 probe of the environment, rather than trusting `MCP_MAJOR` on its own.
+
+The independent probe is the INSTALLED DISTRIBUTION's major version
+(`importlib.metadata.version("mcp")`), not the presence of a module path.
+Module presence stopped being a discriminator at mcp 2.1: 2.0.0 removed
+`mcp.server.fastmcp`, and 2.1.x ships it again alongside the canonical
+`mcp.server.mcpserver`. A probe that read "fastmcp importable" as "1.x"
+failed on 2.1.1 while the shim (which imports the canonical 2.x names first)
+was right. Presence of `mcp.server.fastmcp` therefore proves nothing about
+the line; the canonical 2.x module is what distinguishes 2.x, and the
+distribution version is what the environment actually says.
 """
 from __future__ import annotations
 
+import importlib.metadata
 import importlib.util
 
 import pytest
@@ -22,23 +33,66 @@ from yantrikdb_mcp._compat import (
 )
 
 
-def _fastmcp_present() -> bool:
-    """Independent probe: does the 1.x module tree exist in this env?"""
+def _installed_major() -> int:
+    """Independent probe: the major of the `mcp` distribution that pip
+    installed — read from package metadata, not from which modules import."""
+    return int(importlib.metadata.version("mcp").split(".", 1)[0])
+
+
+def _module_present(name: str) -> bool:
     try:
-        return importlib.util.find_spec("mcp.server.fastmcp") is not None
+        return importlib.util.find_spec(name) is not None
     except (ImportError, ValueError):
         return False
 
 
+def _canonical_2x_server_present() -> bool:
+    """The 2.x-only module tree (`mcp.server.mcpserver`)."""
+    return _module_present("mcp.server.mcpserver")
+
+
+def _fastmcp_present() -> bool:
+    """The 1.x module tree — ALSO present on 2.1.x, so never a discriminator
+    on its own. Kept only to describe the environment in assertion messages
+    and to pin the 2.1.x shape below."""
+    return _module_present("mcp.server.fastmcp")
+
+
 def test_major_matches_an_independent_probe() -> None:
-    """The shim's verdict must agree with the environment, not just be
-    self-consistent."""
-    expected = 1 if _fastmcp_present() else 2
+    """The shim's verdict must agree with the installed distribution, not just
+    be self-consistent."""
+    expected = _installed_major()
+    assert expected in (1, 2), f"unexpected installed mcp major: {expected}"
     assert MCP_MAJOR == expected, (
-        f"_compat resolved {sdk_line()} but mcp.server.fastmcp "
-        f"{'IS' if _fastmcp_present() else 'is NOT'} importable — the shim "
-        f"picked the wrong branch."
+        f"_compat resolved {sdk_line()} but the installed mcp distribution is "
+        f"{importlib.metadata.version('mcp')} — the shim picked the wrong branch."
     )
+
+
+def test_canonical_server_module_agrees_with_the_major() -> None:
+    """On 2.x the canonical `mcp.server.mcpserver` tree must exist (that is
+    what the shim imports first); on 1.x it must not. This is the module-level
+    cross-check that survives 2.1.x — unlike fastmcp presence."""
+    assert _canonical_2x_server_present() == (MCP_MAJOR == 2), (
+        f"{sdk_line()} resolved, but mcp.server.mcpserver "
+        f"{'IS' if _canonical_2x_server_present() else 'is NOT'} importable"
+    )
+
+
+@pytest.mark.skipif(
+    not (_fastmcp_present() and _canonical_2x_server_present()),
+    reason="regression shape needs BOTH module trees importable (mcp 2.1.x)",
+)
+def test_both_module_trees_importable_resolves_to_2x() -> None:
+    """Regression for mcp 2.1.1: `mcp.server.fastmcp` AND
+    `mcp.server.mcpserver` are both importable. The shim must choose 2.x
+    (canonical names first) and the tests must not infer 1.x from the
+    reappearance of the fastmcp path."""
+    assert MCP_MAJOR == 2, (
+        f"both module trees present (mcp {importlib.metadata.version('mcp')}) "
+        f"but the shim resolved {sdk_line()}"
+    )
+    assert _installed_major() == 2
 
 
 def test_all_exported_symbols_are_usable() -> None:


### PR DESCRIPTION
Two commits, deliberately separate:

1. **`deps: admit engine 0.16.x and 0.17.x (<0.18.0)`** — one line in `pyproject.toml`. The ceiling had stayed at `<0.16.0` while the engine shipped 0.16.0 and 0.17.0; the CT128 deployment had been running this server on a violated pin. Floor unchanged.
2. **`tests: probe the installed mcp major, not fastmcp presence`** — test/doc-only, runtime `_compat.py` unchanged. MCP SDK 2.1.1 ships `mcp.server.fastmcp` again alongside the canonical `mcp.server.mcpserver`, so the old independent probe ("fastmcp importable ⇒ 1.x") contradicted a shim that had correctly chosen 2.x; `main` is red on CI against 2.1.1 for that reason, independent of the engine. The probe now reads `importlib.metadata.version("mcp")`, a second test ties the canonical 2.x module tree to `MCP_MAJOR`, and a regression test pins the both-trees-importable shape to 2.x. Validated on mcp 1.29.1, 2.0.0 and 2.1.1.

**Verification (CI's exact splits, under resolved mcp 2.1.1):** engine 0.16.0 → 288 passed / 3 skipped / 1 xfailed, e2e 5 passed (Windows); engine 0.17.0 → 288/3/1, e2e 5 (Windows and Linux); normal-resolution install against published `yantrikdb==0.17.0`, `pip check` clean, stdio `initialize` handshake valid. Dogfooded on the CT128 memory server (HTTP `initialize` + `tools/list` over StreamableHTTP, 20 tools, rows/integrity unchanged).

No version bump here — `server.json`/package version sync is left for the release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)