### PR TITLE
deps: admit engine 0.18.x (<0.19.0); v0.19.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.19.3"
+version = "0.19.4"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"
@@ -130,7 +130,7 @@ dependencies = [
     # that still admits an AGPL engine makes "permissively licensed end to end"
     # true only by luck of resolution order. 0.15.4 is behavior-identical to
     # 0.15.3 — the relicense carried no code change.
-    "yantrikdb>=0.15.4,<0.18.0",
+    "yantrikdb>=0.15.4,<0.19.0",
     # D3 firewall, same rule as the engine pin above — and for the same
     # reason, learned the same way. `mcp[cli]>=1.2.0` was UNBOUNDED, so the
     # day the SDK shipped 2.0.0 it removed `mcp.server.fastmcp` and every

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/yantrikos/yantrikdb-mcp",
     "source": "github"
   },
-  "version": "0.19.3",
+  "version": "0.19.4",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "yantrikdb-mcp",
-      "version": "0.19.3",
+      "version": "0.19.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Engine 0.18.0 is published and additive (pack substrate: structured `hit["pack"]` provenance, signed settings on `mounted_packs()`, `pack_context_for`, `recall_from_packs_for`, `PackNotMounted`; plus the fix that makes every pack published before 0.16 mountable again).

Pin `yantrikdb>=0.15.4,<0.19.0` (was `<0.18.0`). No MCP tool change in this release — the pin lift is the whole delta.

Verified against the 0.18.0 wheel in a clean venv before release: `pip check` clean, suite 293 passed / 3 skipped / 1 xfailed.