### PR TITLE
fix: recall(order=...) — the sequence the caller asked for

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,28 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+
+# ── Local config that carries credentials ────────────────────────────
+# `.mcp.json` holds live API keys. It was swept into a commit here by a
+# careless `git add -A` on 2026-08-26 and only GitHub's push protection
+# stopped it from being published. The core and server repos had already
+# ignored it; this one had not.
+.mcp.json
+.mcp.local.json
+.env
+.env.*
+!.env.example
+.claude/
+*.local.json
+
+# ── Build artifacts ──────────────────────────────────────────────────
+dist/
+dist-*/
+build/
+*.egg-info/
+*.mcpb
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.19.4"
+version = "0.19.5"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/yantrikos/yantrikdb-mcp",
     "source": "github"
   },
-  "version": "0.19.4",
+  "version": "0.19.5",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "yantrikdb-mcp",
-      "version": "0.19.4",
+      "version": "0.19.5",
       "transport": {
         "type": "stdio"
       },

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -582,6 +582,7 @@ def recall(
     include_superseded: bool = False,
     expand_entities: bool = True,
     min_score_ratio: float | None = None,
+    order: str | None = None,
     since: str | None = None,
     until: str | None = None,
     refine_from: str | None = None,
@@ -593,6 +594,12 @@ def recall(
     MODES:
     - **Search** (default): recall("project architecture decisions")
     - **Refine**: recall("PostgreSQL vs MySQL decision", refine_from="database choice", refine_exclude=["rid1"])
+
+    ORDER: by default results come back by relevance. Pass
+    order="recency" for newest-first, order="first_mention" (alias
+    "chronological") for oldest-first, or order="certainty". Ordering
+    re-sorts the top_k the search already selected — it does not widen
+    the search — and the confidence hints are omitted on that path.
     (Relevance feedback moved to memory(action="feedback") in v0.10 — recall
     is now purely read-only.)
 
@@ -696,8 +703,26 @@ def recall(
             "count": len(items), "results": items,
             "confidence": round(response["confidence"], 4), "hints": hints}))
 
+    # ORDER re-sorts the final top_k: "relevance" (default), "certainty",
+    # "recency", or "first_mention" (ascending; "chronological" is an alias).
+    #
+    # Only row-level `db.recall()` implements it — `db.recall_with_response()`,
+    # the default path here, does not. Rather than accept the argument and let
+    # it do nothing on the common path (the failure this fixes: `order` was not
+    # a parameter at all, so passing it was silently ignored), an explicit
+    # order routes through `db.recall()`, which is the same escape hatch
+    # `include_superseded` already uses. The cost is the hints envelope, which
+    # that path does not produce; that is stated rather than hidden.
+    _ORDERS = ("relevance", "certainty", "recency", "first_mention", "chronological")
+    if order is not None:
+        if order not in _ORDERS:
+            raise ToolError(
+                f"order must be one of {', '.join(_ORDERS)} (got {order!r})")
+        if refine_from:
+            raise ToolError("order is not supported when refining; refine first, then recall with order")
+
     # Search mode (default)
-    if include_superseded:
+    if include_superseded or (order is not None and order != "relevance"):
         # recall_with_response has no include_superseded flag (gap reported
         # to core 2026-07-17) — the archaeology path goes through db.recall,
         # which returns the same per-item fields minus the hints envelope.
@@ -706,7 +731,8 @@ def recall(
             include_consolidated=include_consolidated,
             expand_entities=expand_entities,
             namespace=namespace, domain=domain, source=source,
-            include_superseded=True,
+            include_superseded=include_superseded,
+            order=order,
             time_window=time_window,
         )
         response = {

--- a/tests/test_recall_order.py
+++ b/tests/test_recall_order.py
@@ -1,0 +1,122 @@
+"""recall(order=...) — the sequence the caller asked for.
+
+The failure this fixes, found 2026-08-26 by testing the live production
+store: `recall(query="CT128 deploy", top_k=4, order="recency")` and the
+same call with no order returned BYTE-IDENTICAL results — same rids, same
+sequence, same scores — and that sequence was not recency (2026-07-17,
+08-20, 08-20, 06-23). `order` was not a parameter of this tool at all, so
+passing it was silently ignored rather than rejected.
+
+The engine has honoured `order` since #46: verified directly on 0.18.0
+with rows aged 300/200/100/1 days, order="recency" returns 1/100/200/300
+and order="first_mention" returns 300/200/100/1. Only the MCP layer was
+missing.
+
+This is the second time this exact shape has bitten this tool —
+test_time_window_range.py exists because `since`/`until` were silently
+dropped — so these tests assert the thing that catches it: that two
+different orders produce DIFFERENT sequences. A test that merely checked
+`order="recency"` returns rows would have passed against the broken
+build.
+"""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from yantrikdb_mcp._compat import ToolError
+from yantrikdb_mcp.tools import recall
+
+
+class _Ctx:
+    def __init__(self, db):
+        self.request_context = type(
+            "R", (), {"lifespan_context": {"lazy": type("L", (), {"db": db})()}}
+        )()
+
+
+@pytest.fixture
+def ctx(tmp_path):
+    import os
+
+    os.environ.setdefault("YANTRIKDB_EMBEDDER", "bundled")
+    from yantrikdb_mcp.embedder import load_engine
+
+    db = load_engine(str(tmp_path / "order.db"), model_name="bundled")
+    yield _Ctx(db)
+    try:
+        db.close()
+    except AttributeError:
+        pass
+
+
+def _seed_ages(ctx):
+    """Four equally-relevant rows at known, well-separated ages."""
+    db = ctx.request_context.lifespan_context["lazy"].db
+    now = time.time()
+    for text, age_days in [
+        ("deploy runbook alpha", 300),
+        ("deploy runbook beta", 200),
+        ("deploy runbook gamma", 100),
+        ("deploy runbook delta", 1),
+    ]:
+        db.record(
+            text, memory_type="episodic", namespace="ord",
+            created_at=now - age_days * 86400,
+        )
+    return now
+
+
+def _labels(payload):
+    return [r["text"].split()[-1] for r in json.loads(payload)["results"]]
+
+
+def test_recency_puts_the_newest_first(ctx):
+    _seed_ages(ctx)
+    labels = _labels(recall("deploy runbook", top_k=4, order="recency", ctx=ctx))
+    assert labels == ["delta", "gamma", "beta", "alpha"], labels
+
+
+def test_first_mention_puts_the_oldest_first(ctx):
+    _seed_ages(ctx)
+    labels = _labels(recall("deploy runbook", top_k=4, order="first_mention", ctx=ctx))
+    assert labels == ["alpha", "beta", "gamma", "delta"], labels
+
+
+def test_chronological_is_an_alias_for_first_mention(ctx):
+    _seed_ages(ctx)
+    a = _labels(recall("deploy runbook", top_k=4, order="chronological", ctx=ctx))
+    b = _labels(recall("deploy runbook", top_k=4, order="first_mention", ctx=ctx))
+    assert a == b, (a, b)
+
+
+def test_two_orders_do_not_produce_the_same_sequence(ctx):
+    """The assertion that would have caught the original defect.
+
+    When `order` was ignored, every order returned the identical sequence.
+    Checking that a given order 'returns rows' passes against that bug;
+    checking that two orders DIFFER does not.
+    """
+    _seed_ages(ctx)
+    newest = _labels(recall("deploy runbook", top_k=4, order="recency", ctx=ctx))
+    oldest = _labels(recall("deploy runbook", top_k=4, order="first_mention", ctx=ctx))
+    assert newest != oldest, f"order had no effect: {newest}"
+    assert newest == list(reversed(oldest)), (newest, oldest)
+
+
+def test_an_unknown_order_is_refused_not_ignored(ctx):
+    _seed_ages(ctx)
+    with pytest.raises(ToolError, match="order must be one of"):
+        recall("deploy runbook", top_k=4, order="sideways", ctx=ctx)
+
+
+def test_omitting_order_still_ranks_by_relevance(ctx):
+    """The default path must be untouched: no order means the response
+    envelope (confidence + hints) that callers already depend on."""
+    _seed_ages(ctx)
+    payload = json.loads(recall("deploy runbook", top_k=4, ctx=ctx))
+    assert len(payload["results"]) == 4
+    assert "confidence" in payload
+    assert "hints" in payload


### PR DESCRIPTION
Found by testing the live production store:

```
recall("CT128 deploy", top_k=4, order="recency")  → 2026-07-17, 08-20, 08-20, 06-23
recall("CT128 deploy", top_k=4)                    → identical rids, identical order, identical scores
```

**`order` was not a parameter of this tool at all**, so passing it was silently ignored rather than refused — and the sequence returned was not recency.

The engine has honoured `order` since #46. Verified directly on 0.18.0 with rows aged 300/200/100/1 days:

| call | result |
|---|---|
| `order=None` | mixed (relevance) |
| `order="recency"` | 1, 100, 200, 300 ✔ |
| `order="first_mention"` | 300, 200, 100, 1 ✔ |

Only the MCP layer was missing it.

## The routing constraint

Only row-level `db.recall()` implements ordering; `db.recall_with_response()` — the default path here — does not. Rather than accept the argument and let it do nothing on the common path, an explicit order routes through `db.recall()`, the same escape hatch `include_superseded` already uses. The cost is the hints envelope that path doesn't produce, which the docstring states. An unknown order raises rather than being ignored.

That follows the principle already written into this file for `min_score_ratio`: *absent beats advertised-but-inert*.

## The tests assert the thing that catches it

This is the **second time** this shape has bitten this tool — `test_time_window_range.py` exists because `since`/`until` were silently dropped. So the tests check that **two different orders produce different sequences**, not merely that ordering returns rows.

Verified by reverting the fix: **5 of the 6 new tests fail**, and the one that passes is the one testing the untouched default path.

Suite: **299 passed**, 3 skipped, 1 xfailed. Version 0.19.4 → 0.19.5.