### PR TITLE
fix: bring the tools/list schema back under budget on py3.10

### DIFF
--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -595,11 +595,8 @@ def recall(
     - **Search** (default): recall("project architecture decisions")
     - **Refine**: recall("PostgreSQL vs MySQL decision", refine_from="database choice", refine_exclude=["rid1"])
 
-    ORDER: by default results come back by relevance. Pass
-    order="recency" for newest-first, order="first_mention" (alias
-    "chronological") for oldest-first, or order="certainty". Ordering
-    re-sorts the top_k the search already selected — it does not widen
-    the search — and the confidence hints are omitted on that path.
+    ORDER: "recency" | "first_mention" (alias "chronological") |
+    "certainty". Re-sorts the top_k already found; hints omitted.
     (Relevance feedback moved to memory(action="feedback") in v0.10 — recall
     is now purely read-only.)
 

--- a/tests/test_tool_profiles_and_budget.py
+++ b/tests/test_tool_profiles_and_budget.py
@@ -89,7 +89,18 @@ FULL_TOOLS = CORE_TOOLS | {
 #     keyword matches while six in-window memories retrieved zero — an
 #     agent that is never told period questions route to range/since-until
 #     re-creates that failure on every deictic query it makes.
-SCHEMA_BUDGET_CHARS = 48_600
+# 48_600 -> 48_800 (REVIEWED): recall gains `order`. The parameter was
+#     DOCUMENTED as engine behaviour since #46 and was not a parameter of
+#     this tool at all, so `order="recency"` was silently ignored and
+#     returned relevance order — verified on the live store, where ordered
+#     and unordered calls came back byte-identical. Measured 46,640 on
+#     py3.13 and ~48,592 on py3.10 after trimming the prose to two lines;
+#     the ceiling moves 200 so the next honest addition is not decided by
+#     eight characters. And the trap in note (2) caught us AGAIN: py3.10
+#     renders ~1,950 chars more than py3.13 for identical code, so the
+#     local suite passed while CI failed — which is why that follow-up
+#     (measure per-interpreter) is still the right fix.
+SCHEMA_BUDGET_CHARS = 48_800
 
 
 def _rpc(proc, method, params, mid):


### PR DESCRIPTION
**The order fix merged with four red checks — my mistake.** I read the tail of the CI watch output, saw passes, and merged without checking the tally. `Unit tests (py3.10, mcp1/mcp2)` and `(py3.12, mcp1/mcp2)` were failing the schema-budget gate.

The gate was right, and the split is the interesting part:

| Python | schema | vs 48,600 |
|---|---|---|
| 3.13 / 3.14 | 46,845 | +1,755 under ✔ |
| 3.10 / 3.12 | 48,797 | 197 **over** ✘ |

**py3.10 renders ~1,950 chars more than py3.13 for identical code** — `str | None` becomes a fat anyOf. The repo had 197 chars of headroom there and the `order` docstring cost ~350. My local suite (py3.13) structurally could not see it.

## Two changes, in order of preference

1. **Trim the prose** — two lines instead of six, recovering 204 chars. The detail about ordering re-sorting the existing top_k lives in the PR and CHANGELOG, which nobody pays for per session.
2. **Raise the ceiling 48,600 → 48,800**, with the one-line justification the file asks for. The trim alone left **8 chars** of headroom on py3.10 — a coin flip, not a fix.

## Worth naming

Note (2) in that file already warns that CI fails on diffs that look fine locally because the budget must clear the largest supported interpreter — *"exactly what happened here"*. It has now happened twice. Its own recorded follow-up (measure per-interpreter rather than assuming one number fits all) is the real fix, and this diff records the second occurrence.