### PR TITLE
feat: remember(claims=[...]) — state the facts you want tracked; engine 0.19.x admitted (v0.20.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.19.5"
+version = "0.20.0"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"
@@ -130,7 +130,7 @@ dependencies = [
     # that still admits an AGPL engine makes "permissively licensed end to end"
     # true only by luck of resolution order. 0.15.4 is behavior-identical to
     # 0.15.3 — the relicense carried no code change.
-    "yantrikdb>=0.15.4,<0.19.0",
+    "yantrikdb>=0.15.4,<0.20.0",
     # D3 firewall, same rule as the engine pin above — and for the same
     # reason, learned the same way. `mcp[cli]>=1.2.0` was UNBOUNDED, so the
     # day the SDK shipped 2.0.0 it removed `mcp.server.fastmcp` and every

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/yantrikos/yantrikdb-mcp",
     "source": "github"
   },
-  "version": "0.19.5",
+  "version": "0.20.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "yantrikdb-mcp",
-      "version": "0.19.5",
+      "version": "0.20.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/yantrikdb_mcp/http_backend.py
+++ b/src/yantrikdb_mcp/http_backend.py
@@ -843,6 +843,13 @@ class HttpBackend:
             body["domain"] = domain
         return self._post("/v1/session/end", body)
 
+    # ── attach_claims: DELIBERATELY ABSENT, not a raising stub ───────
+    # tools.remember() probes `hasattr(db, "attach_claims")` BEFORE writing
+    # and refuses the whole call (required_engine 0.19.0) when it is
+    # missing, so no memory is ever recorded with its stated claims
+    # dropped. A stub would pass that probe, record the text, then raise.
+    # Add the real method when the server exposes claims over /v1.
+
     # ── maintenance_debt: DELIBERATELY ABSENT, not a raising stub ────
     # The tool layer probes `hasattr(db, "maintenance_debt")` before every
     # opportunistic debt read (remember/recall/think surfacing) and silently

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -339,6 +339,7 @@ def remember(
     summary: str | None = None,
     idempotency_key: str | None = None,
     created_at: str | None = None,
+    claims: list[dict] | None = None,
     ctx: Context = None,
 ) -> str:
     """Store one or more memories in persistent cognitive memory.
@@ -380,8 +381,27 @@ def remember(
             and flattens staleness/decay. Same formats as as_of:
             "2026-08-01", "2026-08-01T14:30:00Z", "7d" (ago), or unix seconds.
             Omit for anything learned in the present conversation.
+        claims: v0.19 engine — facts this memory states, as [{"subject",
+            "relation", "object"}]; state one for any fact you want tracked
+            (contradiction, succession, multi-hop). Subject and object must
+            occur in the text, relation is snake_case; ungrounded ones are
+            reported back, not stored. Batch items take their own "claims".
     """
     db = _get_db(ctx)
+
+    # Stated claims (v0.19 engine). Refused BEFORE any write on an engine
+    # that cannot ground them: recording the text and dropping the claims
+    # would report "recorded" for facts the caller asked to have tracked.
+    batch_claims = any(m.get("claims") for m in (memories or []) if isinstance(m, dict))
+    if (claims or batch_claims) and not hasattr(db, "attach_claims"):
+        return _err(
+            "claims= needs attach_claims on this backend: embedded engine "
+            "v0.19+ (not yet available over the HTTP backend). Nothing was "
+            "recorded — re-run without claims, or upgrade the engine; "
+            "recording the text alone would silently drop the facts you asked "
+            "to have tracked.",
+            required_engine="0.19.0",
+        )
 
     # Backdating (v0.14 engine). Refused loudly rather than dropped on an
     # engine that can't honour it: silently stamping "now" on a memory the
@@ -475,12 +495,16 @@ def remember(
                 "this backend would silently stamp 'now' on backfilled "
                 "history. Remove per-item created_at or upgrade."
             )
+        item_claims = [m.get("claims") or None for m in memories]
         if hasattr(db, "record_batch") and not idempotency_key:
             try:
                 results = db.record_batch(inputs)
                 if isinstance(results, list):
-                    return json.dumps(_attach_write_debt(
-                        db, {"rids": results, "count": len(results), "status": "recorded"}))
+                    out = {"rids": results, "count": len(results), "status": "recorded"}
+                    reports = _attach_item_claims(db, results, item_claims)
+                    if reports:
+                        out["claims"] = reports
+                    return json.dumps(_attach_write_debt(db, out))
             except Exception as e:
                 # Fall through to the per-item loop — but never silently:
                 # if record_batch partially wrote before failing, an unkeyed
@@ -522,8 +546,11 @@ def remember(
                         return translated
                 raise
             results.append(rid)
-        return json.dumps(_attach_write_debt(
-            db, {"rids": results, "count": len(results), "status": "recorded"}))
+        out = {"rids": results, "count": len(results), "status": "recorded"}
+        reports = _attach_item_claims(db, results, item_claims)
+        if reports:
+            out["claims"] = reports
+        return json.dumps(_attach_write_debt(db, out))
 
     # Single mode
     if not text or not text.strip():
@@ -564,7 +591,28 @@ def remember(
             if translated is not None:
                 return translated
         raise
-    return json.dumps(_attach_write_debt(db, {"rid": rid, "status": "recorded"}))
+    out = {"rid": rid, "status": "recorded"}
+    if claims:
+        out["claims"] = _claims_report(db.attach_claims(rid, claims))
+    return json.dumps(_attach_write_debt(db, out))
+
+
+def _claims_report(report: dict) -> dict:
+    """Shape the engine's attach_claims report: a count for what landed, the
+    full rejected list (with reasons) because that is what the caller acts on."""
+    return {
+        "accepted": len(report.get("accepted", [])),
+        "rejected": report.get("rejected", []),
+    }
+
+
+def _attach_item_claims(db, rids: list, item_claims: list) -> dict:
+    """Per-item claims for a batch; keyed by index so a rejection names the item."""
+    reports = {}
+    for i, (rid, cl) in enumerate(zip(rids, item_claims)):
+        if cl:
+            reports[str(i)] = _claims_report(db.attach_claims(rid, cl))
+    return reports
 
 
 # ── 2. recall ──

--- a/tests/test_backend_parity.py
+++ b/tests/test_backend_parity.py
@@ -93,6 +93,12 @@ HASATTR_GUARDED = {
     # remember/recall/think surfacing; no /v1 endpoint yet (future:
     # GET /v1/maintenance/debt). See the comment block in http_backend.py.
     "maintenance_debt",
+    # tools.remember(): `claims=` is refused BEFORE any write when the db
+    # lacks attach_claims (engine < 0.19, or the HTTP backend until the
+    # server exposes it); the refusal names the requirement. A stub would
+    # pass the probe, record the text, then raise — a write with dropped
+    # facts, which is the outcome the probe exists to prevent.
+    "attach_claims",
 }
 
 

--- a/tests/test_remember_claims.py
+++ b/tests/test_remember_claims.py
@@ -1,0 +1,124 @@
+"""remember(claims=[...]) — the writer states the facts, the engine grounds them.
+
+Engine 0.19 extracts only a few relation shapes on its own; anything else
+the caller wants tracked (contradiction, succession, entity threads,
+multi-hop recall) has to be STATED. The tool passes the triples to
+`attach_claims`, which grounds each one mechanically and reports back what
+it refused — the caller acts on the rejected list, so it is returned whole.
+
+The refusal test matters most: a backend without `attach_claims` must not
+record the text and drop the claims, because "recorded" would then be a
+lie about the facts the caller asked to have tracked.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+import pytest
+
+import yantrikdb
+from yantrikdb_mcp.tools import remember
+
+ENGINE_SUPPORTS = hasattr(yantrikdb.YantrikDB, "attach_claims")
+
+
+class _Ctx:
+    def __init__(self, db):
+        self.request_context = type(
+            "R", (), {"lifespan_context": {"lazy": type("L", (), {"db": db})()}}
+        )()
+
+
+@pytest.fixture
+def ctx():
+    os.environ.setdefault("YANTRIKDB_EMBEDDER", "bundled")
+    from yantrikdb_mcp.embedder import load_engine
+
+    db = load_engine(os.path.join(tempfile.mkdtemp(), "cl.db"), model_name="bundled")
+    yield _Ctx(db)
+    try:
+        db.close()
+    except AttributeError:
+        pass
+
+
+def _db(ctx):
+    return ctx.request_context.lifespan_context["lazy"].db
+
+
+@pytest.mark.skipif(not ENGINE_SUPPORTS, reason="engine lacks attach_claims — pre-v0.19")
+def test_grounded_claim_is_stored_and_ungrounded_is_reported(ctx):
+    out = json.loads(remember(
+        text="Alice Moreau works at Fennwick Labs.",
+        namespace="cl",
+        claims=[
+            {"subject": "Alice Moreau", "relation": "works_at", "object": "Fennwick Labs"},
+            # Globex is not in the text: must come back rejected, never stored.
+            {"subject": "Alice Moreau", "relation": "works_at", "object": "Globex"},
+        ],
+        ctx=ctx,
+    ))
+    assert out["status"] == "recorded"
+    assert out["claims"]["accepted"] == 1
+    assert len(out["claims"]["rejected"]) == 1
+    rejected = out["claims"]["rejected"][0]
+    assert "Globex" in json.dumps(rejected)
+    # The accepted claim is queryable through the engine's graph surface.
+    edges = _db(ctx).claims_for_entity("Alice Moreau") if hasattr(_db(ctx), "claims_for_entity") else None
+    if edges is not None:
+        assert any(e.get("dst") == "Fennwick Labs" or e.get("object") == "Fennwick Labs" for e in edges)
+
+
+@pytest.mark.skipif(not ENGINE_SUPPORTS, reason="engine lacks attach_claims — pre-v0.19")
+def test_no_claims_means_no_claims_key(ctx):
+    out = json.loads(remember(text="Plain fact without stated claims.", namespace="cl", ctx=ctx))
+    assert out["status"] == "recorded"
+    assert "claims" not in out
+
+
+@pytest.mark.skipif(not ENGINE_SUPPORTS, reason="engine lacks attach_claims — pre-v0.19")
+def test_batch_items_carry_their_own_claims(ctx):
+    out = json.loads(remember(namespace="cl", memories=[
+        {"text": "Bob Lin leads the Atlas team.",
+         "claims": [{"subject": "Bob Lin", "relation": "leads", "object": "Atlas"}]},
+        {"text": "An item that states nothing."},
+        {"text": "Cara Ito lives in Lisbon.",
+         "claims": [{"subject": "Cara Ito", "relation": "lives_in", "object": "Lisbon"},
+                    {"subject": "Cara Ito", "relation": "lives_in", "object": "Porto"}]},
+    ], ctx=ctx))
+    assert out["count"] == 3
+    reports = out["claims"]
+    assert set(reports) == {"0", "2"}, "only items that stated claims get a report"
+    assert reports["0"]["accepted"] == 1 and reports["0"]["rejected"] == []
+    assert reports["2"]["accepted"] == 1 and len(reports["2"]["rejected"]) == 1
+
+
+def test_engine_without_attach_claims_refuses_before_writing():
+    """An older engine: nothing is recorded, and the error names the fix."""
+    class _OldDb:
+        def __init__(self):
+            self.records = 0
+
+        def record(self, *a, **k):
+            self.records += 1
+            return "rid"
+
+    db = _OldDb()
+    out = json.loads(remember(
+        text="Alice works at Fennwick.",
+        claims=[{"subject": "Alice", "relation": "works_at", "object": "Fennwick"}],
+        ctx=_Ctx(db),
+    ))
+    assert out.get("error") or out.get("status") != "recorded"
+    assert "0.19" in json.dumps(out)
+    assert db.records == 0, "the text must not be recorded when its claims cannot be"
+
+    # Batch form is refused the same way.
+    out = json.loads(remember(memories=[
+        {"text": "x", "claims": [{"subject": "x", "relation": "is", "object": "x"}]},
+    ], ctx=_Ctx(db)))
+    assert db.records == 0
+    assert "0.19" in json.dumps(out)

--- a/tests/test_tool_profiles_and_budget.py
+++ b/tests/test_tool_profiles_and_budget.py
@@ -100,7 +100,14 @@ FULL_TOOLS = CORE_TOOLS | {
 #     renders ~1,950 chars more than py3.13 for identical code, so the
 #     local suite passed while CI failed — which is why that follow-up
 #     (measure per-interpreter) is still the right fix.
-SCHEMA_BUDGET_CHARS = 48_800
+# 48_800 -> 49_300 (REVIEWED): remember gains `claims` for engine 0.19's
+#     cooperative claims. The engine infers only a few relation shapes on
+#     its own; every other fact an agent wants tracked (contradiction,
+#     succession, multi-hop) has to be STATED, and an agent that is never
+#     told the parameter exists never states one — so the five docstring
+#     lines are the feature, not decoration. Measured 49,129 on py3.10
+#     after trimming from ten lines; one `list[dict] | None` param.
+SCHEMA_BUDGET_CHARS = 49_300
 
 
 def _rpc(proc, method, params, mid):


### PR DESCRIPTION
## Summary

`remember(claims=[...])` — the writer states the facts a memory makes; the engine grounds them. Engine pin lifted to `<0.20.0`; server 0.19.5 → 0.20.0.

Engine 0.19 infers only a few relation shapes on its own (anchored templates: works_at, lives_in, runs, leads…). Every other fact an agent wants tracked for contradiction, succession, entity threads and multi-hop recall has to be **stated**, and an agent that is never told the parameter exists never states one. This tool is where that guidance lives.

## What it does

- `remember(text=..., claims=[{"subject", "relation", "object"}, ...])` records the text, then calls the engine's `attach_claims`. Each claim is grounded mechanically (subject and object must occur in the text, relation is a short snake_case phrase); ungrounded claims are **reported back, not stored**. The reply carries `claims: {accepted: n, rejected: [...with reasons]}` — the rejected list is what the caller acts on, so it is returned whole.
- Batch items take their own `"claims"` list; reports are keyed by item index.
- **Honest refusal before any write**: on an engine without `attach_claims` the call returns the `required_engine: "0.19.0"` error and records nothing. Recording the text and dropping the claims would report "recorded" for facts the caller asked to have tracked (the created_at precedent, agreement #6).

## Schema budget

48,800 → 49,300 (reviewed, note in the test): measured 49,129 on py3.10 after trimming the docstring from ten lines to five; one `list[dict] | None` parameter. The five lines are the feature: the engine cannot ask for claims itself.

## Verification

- New `tests/test_remember_claims.py`: grounded claim stored + ungrounded reported; no `claims` key when none given; batch per-item reports; refusal-before-write on an engine without `attach_claims` (both single and batch).
- Full suite on py3.10 against the published engine 0.19.0 wheel: see CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
