### PR TITLE
feat: remember(event_time=...) and claim windows — the temporal tag at ingestion (v0.21.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.20.0"
+version = "0.21.0"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ dependencies = [
     # that still admits an AGPL engine makes "permissively licensed end to end"
     # true only by luck of resolution order. 0.15.4 is behavior-identical to
     # 0.15.3 — the relicense carried no code change.
-    "yantrikdb>=0.15.4,<0.20.0",
+    "yantrikdb>=0.15.4,<0.21.0",
     # D3 firewall, same rule as the engine pin above — and for the same
     # reason, learned the same way. `mcp[cli]>=1.2.0` was UNBOUNDED, so the
     # day the SDK shipped 2.0.0 it removed `mcp.server.fastmcp` and every

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/yantrikos/yantrikdb-mcp",
     "source": "github"
   },
-  "version": "0.20.0",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "yantrikdb-mcp",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -340,6 +340,7 @@ def remember(
     idempotency_key: str | None = None,
     created_at: str | None = None,
     claims: list[dict] | None = None,
+    event_time: str | None = None,
     ctx: Context = None,
 ) -> str:
     """Store one or more memories in persistent cognitive memory.
@@ -386,6 +387,15 @@ def remember(
             (contradiction, succession, multi-hop). Subject and object must
             occur in the text, relation is snake_case; ungrounded ones are
             reported back, not stored. Batch items take their own "claims".
+            A claim may carry "valid_from"/"valid_to" (same formats as
+            created_at) for when the fact held; otherwise it inherits
+            event_time.
+        event_time: when the memory is ABOUT (not when it was written):
+            "2026-08-01", "2026-08-01T14:30:00Z", "7d" (ago) or unix seconds.
+            Sets the record's temporal tag, which time-travel recall reads
+            and every claim on the memory inherits as valid_from — so a
+            fact from 2024 is not a contradiction of the same fact in 2026,
+            it is its predecessor. Batch items take their own "event_time".
     """
     db = _get_db(ctx)
 
@@ -450,7 +460,7 @@ def remember(
                 "memory_type": mt,
                 "importance": max(0.0, min(1.0, mem.get("importance", 0.5))),
                 "valence": max(-1.0, min(1.0, mem.get("valence", 0.0))),
-                "metadata": mem.get("metadata", {}),
+                "metadata": _with_event_time(mem.get("metadata", {}), mem.get("event_time", event_time)),
                 "namespace": mem.get("namespace", namespace),
                 "certainty": max(0.0, min(1.0, mem.get("certainty", 0.8))),
                 "domain": mem.get("domain", "general"),
@@ -495,7 +505,7 @@ def remember(
                 "this backend would silently stamp 'now' on backfilled "
                 "history. Remove per-item created_at or upgrade."
             )
-        item_claims = [m.get("claims") or None for m in memories]
+        item_claims = [_claims_with_windows(m.get("claims")) or None for m in memories]
         if hasattr(db, "record_batch") and not idempotency_key:
             try:
                 results = db.record_batch(inputs)
@@ -576,7 +586,7 @@ def remember(
 
     record_kwargs = dict(
         memory_type=memory_type, importance=importance, valence=valence,
-        metadata=metadata or {}, namespace=namespace, certainty=certainty,
+        metadata=_with_event_time(metadata, event_time), namespace=namespace, certainty=certainty,
         domain=domain, source=source, emotional_state=emotional_state,
     )
     if idempotency_key:
@@ -593,8 +603,38 @@ def remember(
         raise
     out = {"rid": rid, "status": "recorded"}
     if claims:
-        out["claims"] = _claims_report(db.attach_claims(rid, claims))
+        out["claims"] = _claims_report(db.attach_claims(rid, _claims_with_windows(claims)))
     return json.dumps(_attach_write_debt(db, out))
+
+
+def _with_event_time(metadata: dict | None, event_time) -> dict:
+    """Stamp the record's temporal tag: metadata event_time_min/max, which
+    the engine persists as columns and reads for as_of recall and for the
+    validity window of every claim on the memory."""
+    meta = dict(metadata or {})
+    if event_time is not None and event_time != "":
+        ts = _parse_timestamp(event_time, field="event_time")
+        meta.setdefault("event_time_min", ts)
+        meta.setdefault("event_time_max", ts)
+    return meta
+
+
+def _claims_with_windows(claims: list | None) -> list | None:
+    """Turn "valid_from"/"valid_to" on a claim from an agent-supplied instant
+    into the unix float the engine takes; other keys pass through."""
+    if not claims:
+        return claims
+    out = []
+    for c in claims:
+        if not isinstance(c, dict):
+            out.append(c)
+            continue
+        c = dict(c)
+        for k in ("valid_from", "valid_to"):
+            if c.get(k) not in (None, ""):
+                c[k] = _parse_timestamp(c[k], field=k)
+        out.append(c)
+    return out
 
 
 def _claims_report(report: dict) -> dict:

--- a/src/yantrikdb_mcp/tools.py
+++ b/src/yantrikdb_mcp/tools.py
@@ -387,15 +387,11 @@ def remember(
             (contradiction, succession, multi-hop). Subject and object must
             occur in the text, relation is snake_case; ungrounded ones are
             reported back, not stored. Batch items take their own "claims".
-            A claim may carry "valid_from"/"valid_to" (same formats as
-            created_at) for when the fact held; otherwise it inherits
-            event_time.
-        event_time: when the memory is ABOUT (not when it was written):
-            "2026-08-01", "2026-08-01T14:30:00Z", "7d" (ago) or unix seconds.
-            Sets the record's temporal tag, which time-travel recall reads
-            and every claim on the memory inherits as valid_from — so a
-            fact from 2024 is not a contradiction of the same fact in 2026,
-            it is its predecessor. Batch items take their own "event_time".
+            A claim may carry "valid_from"/"valid_to" (created_at formats).
+        event_time: when the memory is ABOUT, not when written (created_at
+            formats). Time-travel recall reads it and every claim on the
+            memory inherits it as valid_from, so an older fact is the
+            predecessor of a newer one, not its contradiction.
     """
     db = _get_db(ctx)
 

--- a/tests/test_remember_event_time.py
+++ b/tests/test_remember_event_time.py
@@ -1,0 +1,107 @@
+"""remember(event_time=...) and claim windows — the temporal tag at ingestion.
+
+A memory can say when it is ABOUT, not only when it was written. The tag
+lands as metadata event_time_min/max (which the engine persists as columns
+and reads for as_of recall) and every claim on the memory inherits it as
+valid_from unless the claim carries its own window. That is what makes a
+2024 fact the predecessor of the same 2026 fact rather than its
+contradiction.
+
+Engine < 0.20 (no StatedClaim windows) still records the tag on the memory;
+only the claim-window checks are skipped there.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+
+import pytest
+
+import yantrikdb
+from yantrikdb_mcp.tools import _claims_with_windows, _with_event_time, remember
+
+ENGINE_CLAIMS = hasattr(yantrikdb.YantrikDB, "attach_claims")
+DAY = 86_400.0
+T_2024 = 1_704_067_200.0  # 2024-01-01T00:00:00Z
+
+
+class _Ctx:
+    def __init__(self, db):
+        self.request_context = type(
+            "R", (), {"lifespan_context": {"lazy": type("L", (), {"db": db})()}}
+        )()
+
+
+@pytest.fixture
+def ctx():
+    os.environ.setdefault("YANTRIKDB_EMBEDDER", "bundled")
+    from yantrikdb_mcp.embedder import load_engine
+
+    db = load_engine(os.path.join(tempfile.mkdtemp(), "et.db"), model_name="bundled")
+    yield _Ctx(db)
+    try:
+        db.close()
+    except AttributeError:
+        pass
+
+
+def _db(ctx):
+    return ctx.request_context.lifespan_context["lazy"].db
+
+
+def test_event_time_parses_the_same_forms_as_created_at():
+    meta = _with_event_time({"topic": "x"}, "2024-01-01")
+    assert meta["topic"] == "x"
+    assert abs(meta["event_time_min"] - T_2024) < DAY and meta["event_time_min"] == meta["event_time_max"]
+    rel = _with_event_time(None, "7d")
+    assert abs(rel["event_time_min"] - (time.time() - 7 * DAY)) < 120
+    assert _with_event_time({"a": 1}, None) == {"a": 1}
+    # An explicit window in metadata is not overwritten by the shorthand.
+    kept = _with_event_time({"event_time_min": 1.0, "event_time_max": 2.0}, "2024-01-01")
+    assert (kept["event_time_min"], kept["event_time_max"]) == (1.0, 2.0)
+
+
+def test_claim_windows_are_parsed_and_other_keys_pass_through():
+    out = _claims_with_windows([
+        {"subject": "A", "relation": "r", "object": "B", "valid_from": "2024-01-01", "valid_to": None},
+        {"subject": "A", "relation": "r", "object": "C"},
+    ])
+    assert abs(out[0]["valid_from"] - T_2024) < DAY and out[0]["valid_to"] is None
+    assert "valid_from" not in out[1]
+    assert _claims_with_windows(None) is None
+
+
+def test_event_time_lands_on_the_record(ctx):
+    rid = json.loads(remember(text="Alice Moreau works at Fennwick Labs.", namespace="et",
+                              event_time="2024-01-01", ctx=ctx))["rid"]
+    stored = _db(ctx).get(rid)
+    meta = stored.get("metadata") or {}
+    if isinstance(meta, str):
+        meta = json.loads(meta)
+    assert abs(meta["event_time_min"] - T_2024) < DAY, stored
+
+
+@pytest.mark.skipif(not ENGINE_CLAIMS, reason="engine lacks attach_claims — pre-v0.19")
+def test_claims_inherit_event_time_and_an_explicit_window_wins(ctx):
+    out = json.loads(remember(
+        text="Alice Moreau works at Fennwick Labs, and Alice Moreau lives in Berlin.",
+        namespace="et", event_time="2024-01-01",
+        claims=[
+            {"subject": "Alice Moreau", "relation": "based_in", "object": "Berlin"},
+            {"subject": "Alice Moreau", "relation": "visited", "object": "Berlin",
+             "valid_from": "2025-01-01", "valid_to": "2025-01-02"},
+        ],
+        ctx=ctx,
+    ))
+    assert out["claims"]["accepted"] == 2, out
+    db = _db(ctx)
+    if not hasattr(db, "get_claims"):
+        pytest.skip("engine lacks get_claims (claim windows) — pre-v0.20")
+    claims = {(c["src"], c["rel_type"], c["dst"]): c for c in db.get_claims("Alice Moreau")}
+    based = claims[("Alice Moreau", "based_in", "Berlin")]
+    visited = claims[("Alice Moreau", "visited", "Berlin")]
+    assert abs(based["valid_from"] - T_2024) < DAY, based
+    assert visited["valid_from"] > based["valid_from"] and visited["valid_to"] > visited["valid_from"], visited

--- a/tests/test_tool_profiles_and_budget.py
+++ b/tests/test_tool_profiles_and_budget.py
@@ -107,7 +107,13 @@ FULL_TOOLS = CORE_TOOLS | {
 #     told the parameter exists never states one — so the five docstring
 #     lines are the feature, not decoration. Measured 49,129 on py3.10
 #     after trimming from ten lines; one `list[dict] | None` param.
-SCHEMA_BUDGET_CHARS = 49_300
+# 49_300 -> 49_700 (REVIEWED): remember gains `event_time` — the temporal
+#     tag. Measured 49,600 on py3.10 after trimming the prose to four
+#     lines; ~300 of the residual is the `str | None` anyOf rendering on
+#     py3.10/3.12 (note 2 above), the rest is the one sentence that tells
+#     an agent WHY to set it (an older fact becomes a predecessor, not a
+#     contradiction) — without that sentence the parameter is never used.
+SCHEMA_BUDGET_CHARS = 49_700
 
 
 def _rpc(proc, method, params, mid):


### PR DESCRIPTION
## Summary

The temporal tag at ingestion, MCP side (engine side: yantrikos/yantrikdb#215).

- `remember(event_time=...)`: when the memory is ABOUT, not when it was written. Same grammar as `created_at` (`"2026-08-01"`, ISO, `"7d"`, unix seconds). Stamps `metadata.event_time_min/max`, which the engine persists as columns and reads for `temporal(as_of=...)`. Batch items take their own `"event_time"`. An explicit window already in metadata is not overwritten.
- Claims may carry `"valid_from"` / `"valid_to"` in the same forms; otherwise every claim on the memory inherits `event_time` as its validity start (engine ≥ 0.20). The conflict scanner treats non-overlapping windows as succession, not contradiction, so a 2024 fact recorded after the same 2026 fact reads as its predecessor.
- Degrades honestly on engine 0.19: the tag lands on the record, claims carry no window; the tests skip the window checks there.

## Verification

- New `tests/test_remember_event_time.py`: grammar parity with created_at; explicit metadata window preserved; claim windows parsed with other keys passing through; tag lands on the record; claims inherit it and an explicit window wins (against the #215 engine build, via the new `get_claims` view).
- Budget test green; parity test green (no new db methods behind a probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
