### PR TITLE
deps: admit engine 0.21.x (<0.22.0); v0.22.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.21.0"
+version = "0.22.0"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"
@@ -130,7 +130,7 @@ dependencies = [
     # that still admits an AGPL engine makes "permissively licensed end to end"
     # true only by luck of resolution order. 0.15.4 is behavior-identical to
     # 0.15.3 — the relicense carried no code change.
-    "yantrikdb>=0.15.4,<0.21.0",
+    "yantrikdb>=0.15.4,<0.22.0",
     # D3 firewall, same rule as the engine pin above — and for the same
     # reason, learned the same way. `mcp[cli]>=1.2.0` was UNBOUNDED, so the
     # day the SDK shipped 2.0.0 it removed `mcp.server.fastmcp` and every

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/yantrikos/yantrikdb-mcp",
     "source": "github"
   },
-  "version": "0.21.0",
+  "version": "0.22.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "yantrikdb-mcp",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Behind yantrikos/yantrikdb#218. Engine 0.21.0 is additive (schema v52, the store's own lexicon for entity admission); no server code change. Suite runs against the resolved engine in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)