### PR TITLE
deps: admit engine 0.22.x (<0.23.0); v0.23.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-mcp"
-version = "0.22.0"
+version = "0.23.0"
 description = "YantrikDB — Cognitive memory for AI agents. Persistent semantic recall, knowledge graph, contradiction detection, and procedural learning. Ships as embeddable engine, network database, or MCP server."
 readme = "README.md"
 license = "MIT"
@@ -130,7 +130,7 @@ dependencies = [
     # that still admits an AGPL engine makes "permissively licensed end to end"
     # true only by luck of resolution order. 0.15.4 is behavior-identical to
     # 0.15.3 — the relicense carried no code change.
-    "yantrikdb>=0.15.4,<0.22.0",
+    "yantrikdb>=0.15.4,<0.23.0",
     # D3 firewall, same rule as the engine pin above — and for the same
     # reason, learned the same way. `mcp[cli]>=1.2.0` was UNBOUNDED, so the
     # day the SDK shipped 2.0.0 it removed `mcp.server.fastmcp` and every

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/yantrikos/yantrikdb-mcp",
     "source": "github"
   },
-  "version": "0.22.0",
+  "version": "0.23.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "yantrikdb-mcp",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Engine 0.22.0 is on PyPI: claim-chain eligibility gate (shadow by default), occurrence-local relation binding with the refusal ledger and silver recall, and the second-SQLite-library guard (yantrikos/yantrikdb#225). Pin `<0.23.0`; version 0.23.0 in pyproject and server.json. This release also carries #42 (the store probe runs in a child process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)